### PR TITLE
Prepare v0.40.0, renames opentelemetry-collector-builder to ocb

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,12 @@ This repository contains a set of resources that ultimately results in OpenTelem
 Each distribution has its own directory at the root of this repository, such as `opentelemetry-collector`. Within each one of those, you'll find at least two files:
 
 - `Dockerfile`, determining how to build the container image for this distribution
-- `manifest.yaml`, which is used with the [opentelemetry-collector-builder](https://github.com/open-telemetry/opentelemetry-collector-builder) to generate the sources for the distribution.
+- `manifest.yaml`, which is used with [ocb](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to generate the sources for the distribution.
 
 Within each distribution, you are expected to be able to build it using the builder, like:
 
 ```shell
-opentelemetry-collector-builder --config manifest.yaml
+ocb --config manifest.yaml
 ```
 
 You can build all distributions by running:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO=$(shell which go)
-OTELCOL_BUILDER_VERSION ?= 0.37.0
+OTELCOL_BUILDER_VERSION ?= 0.40.0
 OTELCOL_BUILDER_DIR ?= ~/bin
-OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/opentelemetry-collector-builder
+OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 
 YQ_VERSION ?= 4.11.1
 YQ_DIR ?= ${OTELCOL_BUILDER_DIR}
@@ -12,7 +12,7 @@ DISTRIBUTIONS ?= "otelcol"
 ci: check build
 check: ensure-goreleaser-up-to-date
 
-build: otelcol-builder
+build: ocb
 	@./scripts/build.sh -d "${DISTRIBUTIONS}" -b ${OTELCOL_BUILDER} -g ${GO}
 
 generate: generate-sources generate-goreleaser
@@ -20,7 +20,7 @@ generate: generate-sources generate-goreleaser
 generate-goreleaser: yq
 	@./scripts/generate-goreleaser-config.sh -d "${DISTRIBUTIONS}" -y "${YQ}"
 
-generate-sources: otelcol-builder
+generate-sources: ocb
 	@./scripts/build.sh -d "${DISTRIBUTIONS}" -s true -b ${OTELCOL_BUILDER} -g ${GO}
 
 goreleaser-verify:
@@ -29,17 +29,17 @@ goreleaser-verify:
 ensure-goreleaser-up-to-date: generate-goreleaser
 	@git diff -s --exit-code .goreleaser.yaml || (echo "Build failed: The goreleaser templates have changed but the .goreleaser.yaml hasn't. Run 'make generate-goreleaser' and update your PR." && exit 1)
 
-otelcol-builder:
-ifeq (, $(shell which opentelemetry-collector-builder))
+ocb:
+ifeq (, $(shell which ocb))
 	@{ \
 	set -e ;\
 	echo Installing opentelemetry-collector-builder at $(OTELCOL_BUILDER_DIR);\
 	mkdir -p $(OTELCOL_BUILDER_DIR) ;\
-	curl -sLo $(OTELCOL_BUILDER) https://github.com/open-telemetry/opentelemetry-collector-builder/releases/download/v$(OTELCOL_BUILDER_VERSION)/opentelemetry-collector-builder_$(OTELCOL_BUILDER_VERSION)_linux_amd64 ;\
+	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OTELCOL_BUILDER_VERSION)/ocb_$(OTELCOL_BUILDER_VERSION)_linux_amd64" ;\
 	chmod +x $(OTELCOL_BUILDER) ;\
 	}
 else
-OTELCOL_BUILDER=$(shell which opentelemetry-collector-builder)
+OTELCOL_BUILDER=$(shell which ocb)
 endif
 
 yq:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ocb:
 ifeq (, $(shell which ocb))
 	@{ \
 	set -e ;\
-	echo Installing opentelemetry-collector-builder at $(OTELCOL_BUILDER_DIR);\
+	echo Installing ocb at $(OTELCOL_BUILDER_DIR);\
 	mkdir -p $(OTELCOL_BUILDER_DIR) ;\
 	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OTELCOL_BUILDER_VERSION)/ocb_$(OTELCOL_BUILDER_VERSION)_linux_amd64" ;\
 	chmod +x $(OTELCOL_BUILDER) ;\

--- a/distributions/otelcol/manifest.yaml
+++ b/distributions/otelcol/manifest.yaml
@@ -2,50 +2,31 @@ dist:
   module: github.com/open-telemetry/opentelemetry-collector-releases/core
   name: otelcol
   description: OpenTelemetry Collector
-  version: 0.39.0
+  version: 0.40.0
   output_path: ./_build
-  otelcol_version: 0.39.0
+  otelcol_version: 0.40.0
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.39.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.40.0
 exporters:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.39.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.40.0
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.39.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.40.0
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.39.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.39.0
-excludes:
-  - github.com/google/flatbuffers v1.12.0
-replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.39.0
-
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.39.0
-
-  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.39.0
-
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/scraperhelper => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/scraperhelper v0.39.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.39.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.40.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 REPO_DIR="$( cd "$(dirname $( dirname "${BASH_SOURCE[0]}" ))" &> /dev/null && pwd )"
-BUILDER=$(which opentelemetry-collector-builder)
+BUILDER=$(which ocb)
 GO=$(which go)
 
 # default values


### PR DESCRIPTION
Closes open-telemetry/opentelemetry-collector#4482

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
