### PR TITLE
Fix systemd unit file for otelcol

### DIFF
--- a/distributions/otelcol/otelcol.conf
+++ b/distributions/otelcol/otelcol.conf
@@ -1,5 +1,5 @@
-# Systemd environment file for the opentelemetry-collector service
+# Systemd environment file for the otelcol service
 
-# Command-line options for the opentelemetry-collector service.
-# Run `/usr/bin/opentelemetry-collector --help` to see all available options.
-OTELCOL_OPTIONS="--config=/etc/opentelemetry-collector/config.yaml"
+# Command-line options for the otelcol service.
+# Run `/usr/bin/otelcol --help` to see all available options.
+OTELCOL_OPTIONS="--config=/etc/otelcol/config.yaml"

--- a/distributions/otelcol/otelcol.service
+++ b/distributions/otelcol/otelcol.service
@@ -3,7 +3,7 @@ Description=OpenTelemetry Collector
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/opentelemetry-collector/otelcol.conf
+EnvironmentFile=/etc/otelcol/otelcol.conf
 ExecStart=/usr/local/bin/otelcol $OTELCOL_OPTIONS
 KillMode=mixed
 Restart=on-failure


### PR DESCRIPTION
Fixes #32

As reported via https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6508, the systemd unit file for the core distribution is currently broken. Turns out, the env file was pointing to non-existing files.

I tested the RPM generated as part of this PR was manually on a fresh Fedora 34 installation.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
