### PR TITLE
Improve the make experience.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,9 @@ for distribution in $(echo $distributions | tr "," "\n")
 do
     pushd "${REPO_DIR}/distributions/${distribution}" > /dev/null
     mkdir -p _build
-
+    echo Building: ${distribution}
+    echo Using Builder: ${BUILDER}
+    echo Using Go: ${GO}
     ${BUILDER} --skip-compilation=${skipcompilation} --go ${GO} --config manifest.yaml > _build/build.log 2>&1
     if [ $? != 0 ]; then
         echo "❌ ERROR: failed to build the distribution '${distribution}'."


### PR DESCRIPTION
* Add checks for all the tools which are used by the build process.
* Switch from `which` to `commmand` since
** `command` is a builtin to the shell.
** This also fixes an issue which was causing tools to be downloaded
   reguardless of whether it has been downloaded previously.

Signed-off-by: Harold Dost <harolddost@gmail.com>