### PR TITLE
Add elasticsearch exporter

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -43,6 +43,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.41.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.41.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter v0.41.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.41.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/f5cloudexporter v0.41.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.41.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.41.0


### PR DESCRIPTION
## What 

Add elasticsearch exporter to the contrib distribution

## Why

The elasticsearch exporter has been in contrib for a while though never got included into the cotrib distribution. 

The functionality added by this module has features whom are usable for elasticsearch without the apm module form elastic which is isn't a opensource module. 

As I am unsure why the module hasn't been added in the first place I'm hoping to also get some backstory about why this is.

I intend to add metrics functionality to the exporter since it has support for logs and traces but metrics aren't supported at the moment.