### PR TITLE
Build ARM64 Docker images

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -18,10 +18,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: "1.17"
 
       - name: Generate the sources
         run: make generate-sources

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,22 +4,31 @@ on:
   push:
     tags: ["v*"]
 
-
-
 jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: "1.17"
 
       - name: Generate distribution sources
         run: make generate-sources

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,9 +59,11 @@ docker_manifests:
   - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
       - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
   - name_template: otel/opentelemetry-collector:{{ .Version }}
     image_templates:
       - otel/opentelemetry-collector:{{ .Version }}-amd64
+      - otel/opentelemetry-collector:{{ .Version }}-arm64
 dockers:
   - image_templates:
       - "otel/opentelemetry-collector-contrib:{{ .Version }}-amd64"
@@ -79,6 +81,21 @@ dockers:
       - "configs/otelcol-contrib.yaml"
     goarch: amd64
   - image_templates:
+      - "otel/opentelemetry-collector-contrib:{{ .Version }}-arm64"
+    dockerfile: "distributions/otelcol-contrib/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - "configs/otelcol-contrib.yaml"
+    goarch: arm64
+  - image_templates:
       - "otel/opentelemetry-collector:{{ .Version }}-amd64"
     dockerfile: "distributions/otelcol/Dockerfile"
     use: buildx
@@ -93,6 +110,21 @@ dockers:
     extra_files:
       - "configs/otelcol.yaml"
     goarch: amd64
+  - image_templates:
+      - "otel/opentelemetry-collector:{{ .Version }}-arm64"
+    dockerfile: "distributions/otelcol/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - "configs/otelcol.yaml"
+    goarch: arm64
 nfpms:
   - id: "otelcol-contrib"
     package_name: "otelcol-contrib"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,25 @@ The main `Makefile` is mostly a wrapper around scripts under the [./scripts](./s
 
 [goreleaser](https://goreleaser.com) plays a big role in producing the final artifacts. Given that the final configuration file for this tool would be huge and would cause relatively big changes for each new distribution, a `Makefile` target exists to generate the `.goreleaser.yaml` for the repository. The `Makefile` contains a list of distributions (`DISTRIBUTIONS`) that is passed down to the script, which will generate snippets based on the templates from `./scripts/goreleaser-templates/`. Adding a new distribution is then only a matter of adding the distribution's directory, plus adding it to the Makefile. Adding a new snippet is only a matter of adding a new template.
 
-Once there's a change either to the templates or to the list of distributions, a new `.goreleaser` file can be generated with:
+Once there's a change either to the templates or to the list of distributions, a new `.goreleaser.yaml` file can be generated with:
 
 ```shell
 make generate-goreleaser
+```
+
+After that, you can test the goreleaser build process with:
+
+```shell
+make goreleaser-verify
+```
+
+#### Building multi-architecture Docker images
+
+goreleaser will build Docker images for x86_64 and arm64 processors. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
+
+This is accomplished by installing [qemu](https://www.qemu.org/), and then [enabling support](https://github.com/multiarch/qemu-user-static#readme) for qemu within Docker:
+
+```shell
+apt-get install qemu binfmt-support qemu-user-static
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-OpenTelemetry Collector distributions
-===
+# OpenTelemetry Collector distributions
 
 This repository assembles OpenTelemetry Collector distributions, such as the "core" distribution, or "contrib". It may contain non-official distributions, focused on specific use-cases, such as the load-balancer.
 
 Each distribution contains:
 
 - Binaries for a multitude of platforms and architectures
-- Multi-arch container images
+- Multi-arch container images (x86_64 and arm64)
 - Packages to be used with Linux distributions (apk, RPM, deb), Mac OS (brew)
 
 More details about each individual distribution can be seen in its own readme files.

--- a/scripts/goreleaser-templates/docker-manifests.template.yaml
+++ b/scripts/goreleaser-templates/docker-manifests.template.yaml
@@ -2,3 +2,4 @@ docker_manifests:
   - name_template: ${CONTAINER_BASE_NAME}:{{ .Version }}
     image_templates:
       - ${CONTAINER_BASE_NAME}:{{ .Version }}-amd64
+      - ${CONTAINER_BASE_NAME}:{{ .Version }}-arm64

--- a/scripts/goreleaser-templates/docker.template.yaml
+++ b/scripts/goreleaser-templates/docker.template.yaml
@@ -14,3 +14,18 @@ dockers:
     extra_files:
       - "configs/{distribution}.yaml"
     goarch: amd64
+  - image_templates:
+      - "${CONTAINER_BASE_NAME}:{{ .Version }}-arm64"
+    dockerfile: "distributions/{distribution}/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - "configs/{distribution}.yaml"
+    goarch: arm64


### PR DESCRIPTION
#39 added support for ARM + ARM64 multi-arch builds, but in #40 a project maintainer reported no longer being able to run goreleaser builds, and reverted it.

ARM(32) builds were removed from goreleaser entirely in #43, so this PR just adds back ARM64 Docker builds. It also updates the GitHub Actions workflows to install support for building the cross-architecture image, and updates the contributing docs with notes about how to set that up on a local system.