### PR TITLE
Publish images to Github container registry (GHCR)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,13 @@ jobs:
       - name: Log into Docker.io
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v1.12.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -110,7 +110,8 @@ dockers:
   dockerfile: distributions/otelcol/Dockerfile
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-386
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-386
   extra_files:
   - configs/otelcol.yaml
   build_flag_templates:
@@ -127,7 +128,8 @@ dockers:
   dockerfile: distributions/otelcol/Dockerfile
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-amd64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-amd64
   extra_files:
   - configs/otelcol.yaml
   build_flag_templates:
@@ -144,7 +146,8 @@ dockers:
   dockerfile: distributions/otelcol/Dockerfile
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-arm64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-arm64
   extra_files:
   - configs/otelcol.yaml
   build_flag_templates:
@@ -161,7 +164,8 @@ dockers:
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-386
   extra_files:
   - configs/otelcol-contrib.yaml
   build_flag_templates:
@@ -178,7 +182,8 @@ dockers:
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-amd64
   extra_files:
   - configs/otelcol-contrib.yaml
   build_flag_templates:
@@ -195,7 +200,8 @@ dockers:
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-arm64
   extra_files:
   - configs/otelcol-contrib.yaml
   build_flag_templates:
@@ -213,14 +219,26 @@ docker_manifests:
   - otel/opentelemetry-collector:{{ .Version }}-386
   - otel/opentelemetry-collector:{{ .Version }}-amd64
   - otel/opentelemetry-collector:{{ .Version }}-arm64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+- name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}
+  image_templates:
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-arm64
 - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+- name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}
+  image_templates:
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -110,6 +110,7 @@ dockers:
   dockerfile: distributions/otelcol/Dockerfile
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
   extra_files:
   - configs/otelcol.yaml
   build_flag_templates:
@@ -126,6 +127,7 @@ dockers:
   dockerfile: distributions/otelcol/Dockerfile
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
   extra_files:
   - configs/otelcol.yaml
   build_flag_templates:
@@ -142,6 +144,7 @@ dockers:
   dockerfile: distributions/otelcol/Dockerfile
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
   extra_files:
   - configs/otelcol.yaml
   build_flag_templates:
@@ -158,6 +161,7 @@ dockers:
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
   extra_files:
   - configs/otelcol-contrib.yaml
   build_flag_templates:
@@ -174,6 +178,7 @@ dockers:
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
   extra_files:
   - configs/otelcol-contrib.yaml
   build_flag_templates:
@@ -190,6 +195,7 @@ dockers:
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
   extra_files:
   - configs/otelcol-contrib.yaml
   build_flag_templates:
@@ -207,8 +213,14 @@ docker_manifests:
   - otel/opentelemetry-collector:{{ .Version }}-386
   - otel/opentelemetry-collector:{{ .Version }}-amd64
   - otel/opentelemetry-collector:{{ .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
 - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64

--- a/goreleaser/configure.go
+++ b/goreleaser/configure.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	ImagePrefixes = []string{"otel"}
+	ImagePrefixes = []string{"otel", "ghcr.io/open-telemetry/opentelemetry-collector-releases"}
 	Architectures = []string{"386", "amd64", "arm64"}
 
 	distsFlag = flag.String("d", "", "Collector distributions(s) to build, comma-separated")


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Resolves #49 

The main motivation is to make clear what images are published - the images will be directly linked to this repository. The second motivation is to overcome dockerhub pull limits.

Disclaimer I haven't tested it and I don't have much experience with goreleaser.