### PR TITLE
Replace 'upstream' remote by a concrete repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ add-tag:
 push-tag:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
 	@echo "Pushing tag ${TAG}"
-	@git push upstream ${TAG}
+	@git push git@github.com:open-telemetry/opentelemetry-collector-releases.git ${TAG}


### PR DESCRIPTION
Related to open-telemetry/opentelemetry-collector#4881

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
