### PR TITLE
Keep latest Docker image tag up to date

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,11 @@ jobs:
       - name: Generate distribution sources
         run: make generate-sources
 
-      - name: Log into Docker.io
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1.12.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@v1.12.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,3 +53,13 @@ jobs:
           args: release --rm-dist --timeout 1h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest tag
+        uses: silverlyra/latest-image-action@v0.1.0
+        with:
+          repository: |
+            otel/opentelemetry-collector
+            otel/opentelemetry-collector-contib
+            ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector
+            ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contib
+          candidate-tag: ${{ github.ref_name }}


### PR DESCRIPTION
This adds [an action][lia] to the end of the release workflow. After goreleaser pushes the Docker images, this action will semver-compare the newly-pushed image version against `latest`. If the new version is newer (and not a prerelease), it overwrites `latest` with the new manifest.

I’d been struggling to find a tidy way to do this, and ended up writing this GitHub Action just to do this one thing. 🙃

[lia]: https://github.com/silverlyra/latest-image-action

Fixes #73.