### PR TITLE
[manifests] Remove unnecessary replaces

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -144,3 +144,8 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.47.0
+
+# When adding a replace, add a comment before it to document why it's needed and when it can be removed
+replaces:
+  # See https://github.com/google/gnostic/issues/262
+  - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -144,6 +144,3 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.47.0
-
-replaces:
-  - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -146,11 +146,4 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.47.0
 
 replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent  => github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.47.0
   - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5

--- a/distributions/otelcol/manifest.yaml
+++ b/distributions/otelcol/manifest.yaml
@@ -49,7 +49,3 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.47.0
-
-replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.47.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.47.0


### PR DESCRIPTION
**Description**: Remove `replace` directives that are no longer necessary.

They were added by @svrakitin in #62, but can now be removed according to https://github.com/open-telemetry/opentelemetry-collector-releases/pull/62#issuecomment-1019220331
