### PR TITLE
Add mongodb receiver to collector-contrib manifest

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -123,6 +123,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.47.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.47.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.47.0


### PR DESCRIPTION
Adding (MongoDB receiver)[https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbreceiver] to manifest