### PR TITLE
Remove Darwin 32-bit release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,8 @@ builds:
   - amd64
   - arm64
   ignore:
+  - goos: darwin
+    goarch: "386"
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol-contrib/_build

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,6 @@ builds:
   - amd64
   - arm64
   ignore:
-  - goos: darwin
-    goarch: "386"
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol/_build

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,8 @@ builds:
   - amd64
   - arm64
   ignore:
+  - goos: darwin
+    goarch: "386"
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol/_build

--- a/goreleaser/configure.go
+++ b/goreleaser/configure.go
@@ -85,6 +85,7 @@ func Build(dist string) config.Build {
 		Goos:   []string{"darwin", "linux", "windows"},
 		Goarch: architecturesForDist(dist),
 		Ignore: []config.IgnoredBuild{
+			{Goos: "darwin", Goarch: "386"},
 			{Goos: "windows", Goarch: "arm64"},
 		},
 	}


### PR DESCRIPTION
Darwin 386 build is no longer supported by Go. This is because it dropped support for 32-bit binaries on macOS in [Go 1.15](https://go.dev/doc/go1.15). It makes sense therefore to drop this binary equivalent for the collector also.

Fixes #97 

Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>