### PR TITLE
[processor/transform] Add transform processor to distribution

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -94,6 +94,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.51.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.51.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver


### PR DESCRIPTION
This PR adds the transform processor to the contrib distribution.

Tracking transformprocessor alpha release via https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8252