### PR TITLE
add linux-arm builds to releaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,9 +9,14 @@ builds:
   - "386"
   - amd64
   - arm64
+  - arm
   ignore:
   - goos: darwin
     goarch: "386"
+  - os: darwin
+    arch: arm
+  - os: windows
+    arch: arm    
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol/_build
@@ -32,9 +37,14 @@ builds:
   - "386"
   - amd64
   - arm64
+  - arm
   ignore:
   - goos: darwin
     goarch: "386"
+  - os: darwin
+    arch: arm
+  - os: windows
+    arch: arm    
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol-contrib/_build
@@ -164,6 +174,24 @@ dockers:
   - --label=org.opencontainers.image.source={{.GitURL}}
   use: buildx
 - goos: linux
+  goarch: arm
+  dockerfile: distributions/otelcol/Dockerfile
+  image_templates:
+  - otel/opentelemetry-collector:{{ .Version }}-arm
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-arm
+  extra_files:
+  - configs/otelcol.yaml
+  build_flag_templates:
+  - --pull
+  - --platform=linux/arm
+  - --label=org.opencontainers.image.created={{.Date}}
+  - --label=org.opencontainers.image.name={{.ProjectName}}
+  - --label=org.opencontainers.image.revision={{.FullCommit}}
+  - --label=org.opencontainers.image.version={{.Version}}
+  - --label=org.opencontainers.image.source={{.GitURL}}
+  use: buildx
+- goos: linux
   goarch: "386"
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
@@ -217,12 +245,31 @@ dockers:
   - --label=org.opencontainers.image.version={{.Version}}
   - --label=org.opencontainers.image.source={{.GitURL}}
   use: buildx
+- goos: linux
+  goarch: arm
+  dockerfile: distributions/otelcol-contrib/Dockerfile
+  image_templates:
+  - otel/opentelemetry-collector-contrib:{{ .Version }}-arm
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-arm
+  extra_files:
+  - configs/otelcol-contrib.yaml
+  build_flag_templates:
+  - --pull
+  - --platform=linux/arm
+  - --label=org.opencontainers.image.created={{.Date}}
+  - --label=org.opencontainers.image.name={{.ProjectName}}
+  - --label=org.opencontainers.image.revision={{.FullCommit}}
+  - --label=org.opencontainers.image.version={{.Version}}
+  - --label=org.opencontainers.image.source={{.GitURL}}
+  use: buildx
 docker_manifests:
 - name_template: otel/opentelemetry-collector:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-386
   - otel/opentelemetry-collector:{{ .Version }}-amd64
   - otel/opentelemetry-collector:{{ .Version }}-arm64
+  - otel/opentelemetry-collector:{{ .Version }}-arm
 - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
     .Version }}
   image_templates:
@@ -232,11 +279,14 @@ docker_manifests:
     .Version }}-amd64
   - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
     .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-arm
 - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+  - otel/opentelemetry-collector-contrib:{{ .Version }}-arm
 - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
     .Version }}
   image_templates:
@@ -246,3 +296,5 @@ docker_manifests:
     .Version }}-amd64
   - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
     .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-arm

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,10 +13,10 @@ builds:
   ignore:
   - goos: darwin
     goarch: "386"
-  - os: darwin
-    arch: arm
-  - os: windows
-    arch: arm    
+  - goos: darwin
+    goarch: arm
+  - goos: windows
+    goarch: arm
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol/_build
@@ -41,10 +41,10 @@ builds:
   ignore:
   - goos: darwin
     goarch: "386"
-  - os: darwin
-    arch: arm
-  - os: windows
-    arch: arm    
+  - goos: darwin
+    goarch: arm
+  - goos: windows
+    goarch: arm
   - goos: windows
     goarch: arm64
   dir: distributions/otelcol-contrib/_build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ make goreleaser-verify
 
 #### Building multi-architecture Docker images
 
-goreleaser will build Docker images for x86_64 and arm64 processors. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
+goreleaser will build Docker images for x86_64, 386 arm64 and arm processors. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
 
 This is accomplished by installing [qemu](https://www.qemu.org/), and then [enabling support](https://github.com/multiarch/qemu-user-static#readme) for qemu within Docker:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository assembles OpenTelemetry Collector distributions, such as the "co
 Each distribution contains:
 
 - Binaries for a multitude of platforms and architectures
-- Multi-arch container images (x86_64 and arm64)
+- Multi-arch container images (x86_64, 386, arm64 and arm)
 - Packages to be used with Linux distributions (apk, RPM, deb), Mac OS (brew)
 
 More details about each individual distribution can be seen in its own readme files.

--- a/goreleaser/configure.go
+++ b/goreleaser/configure.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	ImagePrefixes = []string{"otel", "ghcr.io/open-telemetry/opentelemetry-collector-releases"}
-	Architectures = []string{"386", "amd64", "arm64"}
+	Architectures = []string{"386", "amd64", "arm64", "arm"}
 
 	distsFlag = flag.String("d", "", "Collector distributions(s) to build, comma-separated")
 )
@@ -80,6 +80,8 @@ func Build(dist string) config.Build {
 		Goarch: Architectures,
 		Ignore: []config.IgnoredBuild{
 			{Goos: "darwin", Goarch: "386"},
+			{Goos: "darwin", Goarch: "arm"},
+			{Goos: "windows", Goarch: "arm"},
 			{Goos: "windows", Goarch: "arm64"},
 		},
 	}


### PR DESCRIPTION
Fixes #105 . More context and discussions can be read in the issue.

This adds linux-arm builds to the collector and collector contrib, so they can be published to docker hub and consumed on raspberry pi which is running armv7.

This PR follows another PR  for adding this architecture to the CI testing in collector repo [here](https://github.com/open-telemetry/opentelemetry-collector/pull/5472). For contrib, this architecture is also tested in CI [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9b8da699721b3360dc4cc2e5a7e74d74630ced40/.github/workflows/build-and-test.yml#L288)

I added the support by following the way it is done for other os-arch, so please review thoroughly as I have little experience with these tools.

Again, thank you @mx-psi for pointing me to the right places :)
