### PR TITLE
[docs] add descriptions for distros

### DIFF
--- a/distributions/otelcol-contrib/README.md
+++ b/distributions/otelcol-contrib/README.md
@@ -9,7 +9,7 @@ As this distribution contains many components, it is a good starting point to tr
 * reduce the size of the collector, reducing deployment times for the collector
 * improve the security of the collector by reducing the available attack surface area
 
-Building a custom collector can be achieved using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
+Building a [custom collector](https://opentelemetry.io/docs/collector/custom-collector/) can be achieved using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
 
 ## Components
 

--- a/distributions/otelcol-contrib/README.md
+++ b/distributions/otelcol-contrib/README.md
@@ -1,0 +1,16 @@
+# OpenTelemetry Collector Contrib Distro
+
+This distribution contains all the components from both the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) repository and the [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repository. This distribution includes open source and vendor supported components.
+
+## Recommendation
+
+As this distribution contains many components, it is a good starting point to try various configurations. However, when running in production, it is recommended to limit the collector to contain only the components necessary for an environment. Some reasons to do this:
+
+* reduce the size of the collector, reducing deployment times for the collector
+* improve the security of the collector by reducing the available attack surface area
+
+Building a custom collector can be achieved using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
+
+## Components
+
+The full list of components is available in the [manifest](manifest.yaml)

--- a/distributions/otelcol/README.md
+++ b/distributions/otelcol/README.md
@@ -1,0 +1,7 @@
+# OpenTelemetry Collector Distro
+
+This distribution contains all the components from the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) repository and a small selection of  components tied to open source projects from the [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repository.
+
+## Components
+
+The full list of components is available in the [manifest](manifest.yaml)


### PR DESCRIPTION
As the distributions are linked from various places, it makes sense to provide end-users a bit more clarity on what each distro includes.

Fixes #121 