### PR TITLE
Revert "adding support for linux/ppc64le arch (#156)"

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,ppc64le
+          platforms: arm64
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,6 @@ builds:
   - "386"
   - amd64
   - arm64
-  - ppc64le
   ignore:
   - goos: darwin
     goarch: "386"
@@ -33,7 +32,6 @@ builds:
   - "386"
   - amd64
   - arm64
-  - ppc64le
   ignore:
   - goos: darwin
     goarch: "386"
@@ -166,24 +164,6 @@ dockers:
   - --label=org.opencontainers.image.source={{.GitURL}}
   use: buildx
 - goos: linux
-  goarch: ppc64le
-  dockerfile: distributions/otelcol/Dockerfile
-  image_templates:
-  - otel/opentelemetry-collector:{{ .Version }}-ppc64le
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
-    .Version }}-ppc64le
-  extra_files:
-  - configs/otelcol.yaml
-  build_flag_templates:
-  - --pull
-  - --platform=linux/ppc64le
-  - --label=org.opencontainers.image.created={{.Date}}
-  - --label=org.opencontainers.image.name={{.ProjectName}}
-  - --label=org.opencontainers.image.revision={{.FullCommit}}
-  - --label=org.opencontainers.image.version={{.Version}}
-  - --label=org.opencontainers.image.source={{.GitURL}}
-  use: buildx
-- goos: linux
   goarch: "386"
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
@@ -237,31 +217,12 @@ dockers:
   - --label=org.opencontainers.image.version={{.Version}}
   - --label=org.opencontainers.image.source={{.GitURL}}
   use: buildx
-- goos: linux
-  goarch: ppc64le
-  dockerfile: distributions/otelcol-contrib/Dockerfile
-  image_templates:
-  - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
-    .Version }}-ppc64le
-  extra_files:
-  - configs/otelcol-contrib.yaml
-  build_flag_templates:
-  - --pull
-  - --platform=linux/ppc64le
-  - --label=org.opencontainers.image.created={{.Date}}
-  - --label=org.opencontainers.image.name={{.ProjectName}}
-  - --label=org.opencontainers.image.revision={{.FullCommit}}
-  - --label=org.opencontainers.image.version={{.Version}}
-  - --label=org.opencontainers.image.source={{.GitURL}}
-  use: buildx
 docker_manifests:
 - name_template: otel/opentelemetry-collector:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-386
   - otel/opentelemetry-collector:{{ .Version }}-amd64
   - otel/opentelemetry-collector:{{ .Version }}-arm64
-  - otel/opentelemetry-collector:{{ .Version }}-ppc64le
 - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
     .Version }}
   image_templates:
@@ -271,14 +232,11 @@ docker_manifests:
     .Version }}-amd64
   - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
     .Version }}-arm64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
-    .Version }}-ppc64le
 - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-  - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
 - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
     .Version }}
   image_templates:
@@ -288,5 +246,3 @@ docker_manifests:
     .Version }}-amd64
   - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
     .Version }}-arm64
-  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
-    .Version }}-ppc64le

--- a/goreleaser/configure.go
+++ b/goreleaser/configure.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	ImagePrefixes = []string{"otel", "ghcr.io/open-telemetry/opentelemetry-collector-releases"}
-	Architectures = []string{"386", "amd64", "arm64", "ppc64le"}
+	Architectures = []string{"386", "amd64", "arm64"}
 
 	distsFlag = flag.String("d", "", "Collector distributions(s) to build, comma-separated")
 )


### PR DESCRIPTION
This reverts commit dcaae02a419090a19e97d7d820ec9dd54801b74e to unblock the release.

Related issue: https://github.com/open-telemetry/opentelemetry-collector-releases/issues/170