### PR TITLE
re-adding linux/ppc64le support

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,7 @@ builds:
   - "386"
   - amd64
   - arm64
+  - ppc64le
   ignore:
   - goos: darwin
     goarch: "386"
@@ -32,6 +33,7 @@ builds:
   - "386"
   - amd64
   - arm64
+  - ppc64le
   ignore:
   - goos: darwin
     goarch: "386"
@@ -164,6 +166,24 @@ dockers:
   - --label=org.opencontainers.image.source={{.GitURL}}
   use: buildx
 - goos: linux
+  goarch: ppc64le
+  dockerfile: distributions/otelcol/Dockerfile
+  image_templates:
+  - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-ppc64le
+  extra_files:
+  - configs/otelcol.yaml
+  build_flag_templates:
+  - --pull
+  - --platform=linux/ppc64le
+  - --label=org.opencontainers.image.created={{.Date}}
+  - --label=org.opencontainers.image.name={{.ProjectName}}
+  - --label=org.opencontainers.image.revision={{.FullCommit}}
+  - --label=org.opencontainers.image.version={{.Version}}
+  - --label=org.opencontainers.image.source={{.GitURL}}
+  use: buildx
+- goos: linux
   goarch: "386"
   dockerfile: distributions/otelcol-contrib/Dockerfile
   image_templates:
@@ -217,12 +237,31 @@ dockers:
   - --label=org.opencontainers.image.version={{.Version}}
   - --label=org.opencontainers.image.source={{.GitURL}}
   use: buildx
+- goos: linux
+  goarch: ppc64le
+  dockerfile: distributions/otelcol-contrib/Dockerfile
+  image_templates:
+  - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-ppc64le
+  extra_files:
+  - configs/otelcol-contrib.yaml
+  build_flag_templates:
+  - --pull
+  - --platform=linux/ppc64le
+  - --label=org.opencontainers.image.created={{.Date}}
+  - --label=org.opencontainers.image.name={{.ProjectName}}
+  - --label=org.opencontainers.image.revision={{.FullCommit}}
+  - --label=org.opencontainers.image.version={{.Version}}
+  - --label=org.opencontainers.image.source={{.GitURL}}
+  use: buildx
 docker_manifests:
 - name_template: otel/opentelemetry-collector:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector:{{ .Version }}-386
   - otel/opentelemetry-collector:{{ .Version }}-amd64
   - otel/opentelemetry-collector:{{ .Version }}-arm64
+  - otel/opentelemetry-collector:{{ .Version }}-ppc64le
 - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
     .Version }}
   image_templates:
@@ -232,11 +271,14 @@ docker_manifests:
     .Version }}-amd64
   - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
     .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{
+    .Version }}-ppc64le
 - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
   image_templates:
   - otel/opentelemetry-collector-contrib:{{ .Version }}-386
   - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
   - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+  - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
 - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
     .Version }}
   image_templates:
@@ -246,3 +288,5 @@ docker_manifests:
     .Version }}-amd64
   - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
     .Version }}-arm64
+  - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{
+    .Version }}-ppc64le

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,14 @@ This is accomplished by installing [qemu](https://www.qemu.org/), and then [enab
 apt-get install qemu binfmt-support qemu-user-static
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```
+
+### ADDING support for  new platform/architecture 
+- build-test [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector) and [opentelemetry-collector-ccontrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) locally.
+- add support for opentelemetry-colector and opentelemetry-collector-contrib in their respective repository.
+-  Add platform/arch in goreleaser/configure.go.
+- Regenerate the .goreleaser.yml:
+```shell
+make generate-goreleaser
+``` 
+- In setup qemu github action,   add the platform architecture in .github/workflows/ci-goreleaser.yaml  and release.yaml
+- Raised the PR with changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,13 +64,12 @@ apt-get install qemu binfmt-support qemu-user-static
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```
 
-### ADDING support for  new platform/architecture 
-- build-test [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector) and [opentelemetry-collector-ccontrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) locally.
-- add support for opentelemetry-colector and opentelemetry-collector-contrib in their respective repository.
--  Add platform/arch in goreleaser/configure.go.
-- Regenerate the .goreleaser.yml:
-```shell
-make generate-goreleaser
-``` 
-- In setup qemu github action,   add the platform architecture in .github/workflows/ci-goreleaser.yaml  and release.yaml
-- Raised the PR with changes.
+### Adding support for new platforms or architectures
+
+When a new collector distribution image or binary is needed in a different platform or architecture, the following should be considered:
+
+1. Add the new platform or architecture to the Continuous Integration test matrix for both the [core](https://github.com/open-telemetry/opentelemetry-collector) and [contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repositories, to ensure they can be compiled with the new combination. Failing to do so will eventually cause the release to fail due to compilation failures on those uncovered platforms, resulting in them being removed from the release matrix.
+2. In the `goreleaser/configure.go` file, add the new platform or architecture
+3. Regenerate the `.goreleaser` (see [goreleaser](#goreleaser) above)
+4. In the `.github/workflows/ci-goreleaser.yaml` file, under the "Setup QEMU" action, add the new platform and architecture
+5. In the `.github/workflows/release.yaml` file, under the "Setup QEMU" action, add the new platform and architecture

--- a/goreleaser/configure.go
+++ b/goreleaser/configure.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	ImagePrefixes = []string{"otel", "ghcr.io/open-telemetry/opentelemetry-collector-releases"}
-	Architectures = []string{"386", "amd64", "arm64"}
+	Architectures = []string{"386", "amd64", "arm64", "ppc64le"}
 
 	distsFlag = flag.String("d", "", "Collector distributions(s) to build, comma-separated")
 )


### PR DESCRIPTION
- re-adding support for linux/ppc64le arch 
- addressing the [issue 170](https://github.com/open-telemetry/opentelemetry-collector-releases/issues/170)

please review and merge.

