### PR TITLE
Add Instana exporter to otel-contrib distributions

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -53,6 +53,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.59.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/humioexporter v0.59.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.59.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter v0.59.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.59.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter v0.59.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.59.0


### PR DESCRIPTION
Related [#13395](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13395)