### PR TITLE
[chore] Increase GoReleaser timeout to 90 minutes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist --timeout 1h
+          args: release --rm-dist --timeout 90m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The last 2 releases ([0.58.0](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/2967917951/attempts/1) and [0.59.0](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/2843445596/attempts/1)) have had timeouts that required the build to be re-run.  This PR increases the timeout to 90 minutes to try to prevent this as a short-term solution.