### PR TITLE
Upgrade to use go1.19.1, avoids https://nvd.nist.gov/vuln/detail/CVE-2022-27664

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19.1
 
       - name: Generate the sources
         run: make generate-sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19.1
 
       - name: Verify
         run: make ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19.1
 
       - name: Generate distribution sources
         run: make generate-sources


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>