### PR TITLE
[manifests] Add headers_setter extension to contrib build.

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -15,7 +15,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetter v0.61.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13900