### PR TITLE
Add jaegerremotesampling extension to contrib

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -18,6 +18,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetter v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.61.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.61.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.61.0


### PR DESCRIPTION
the remote sampling has been removed from the receiver but its replacement wasn't added to the extensions, cf https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6510

So here it is.