### PR TITLE
bump alpine base image to 3.16

### DIFF
--- a/distributions/otelcol-contrib/Dockerfile
+++ b/distributions/otelcol-contrib/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.13 as certs
+FROM alpine:3.16 as certs
 RUN apk --update add ca-certificates
 
-FROM alpine:3.13 AS otelcol-contrib
+FROM alpine:3.16 AS otelcol-contrib
 COPY otelcol-contrib /otelcol-contrib
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see #1317)

--- a/distributions/otelcol/Dockerfile
+++ b/distributions/otelcol/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.13 as certs
+FROM alpine:3.16 as certs
 RUN apk --update add ca-certificates
 
-FROM alpine:3.13 AS otelcol
+FROM alpine:3.16 AS otelcol
 COPY otelcol /otelcol
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see #1317)


### PR DESCRIPTION
- bump alpine base image to 3.16


We might consider using distroless images to reduce the surface attack and have smaller final images.
if this is the desire of the maintainers I can work on that and maybe we can use https://github.com/chainguard-images/static / https://github.com/chainguard-images/alpine-base

