### PR TITLE
distributions/otelcol-contrib: add datadogprocessor to the manifest

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -77,6 +77,7 @@ processors:
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.68.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogprocessor v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.68.0


### PR DESCRIPTION
Enables the `datadogprocessor` as part of the contrib distribution, introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16607 and approved in issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15689

Depends on:
* https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16607
* Release of v0.68.0 containing the above.