### PR TITLE
[chore] split goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,72 @@ on:
     tags: ["v*"]
 
 jobs:
+  prepare:
+    strategy:
+      matrix:
+        GOOS: [linux, windows, darwin]
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: sigstore/cosign-installer@v2
+
+      - uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64,ppc64le
+
+      - uses: docker/setup-buildx-action@v2
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '~1.19.4'
+          check-latest: true
+
+      - name: Generate distribution sources
+        run: make generate-sources
+
+      - name: Log into Docker.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - shell: bash
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          path: dist/${{ matrix.GOOS }}
+          key: ${{ matrix.GOOS }}-${{ env.sha_short }}
+
+      - uses: goreleaser/goreleaser-action@v4
+        if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: release --rm-dist --split --timeout 2h
+        env:
+          GOOS: ${{ matrix.GOOS }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          COSIGN_EXPERIMENTAL: true
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
   release:
     name: Release
     runs-on: ubuntu-20.04
+    needs: prepare
 
     permissions:
       id-token: write
@@ -15,33 +78,41 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v2
+      - uses: sigstore/cosign-installer@v2
 
-      - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0.13.1
+      - uses: anchore/sbom-action/download-syft@v0.13.1
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64,ppc64le
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v2
 
-      - name: Setup Go
-        uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: '~1.19.4'
           check-latest: true
 
-      - name: Generate distribution sources
-        run: make generate-sources
+      # copy the caches from prepare
+      - shell: bash
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: dist/linux
+          key: linux-${{ env.sha_short }}
+      - uses: actions/cache@v3
+        with:
+          path: dist/darwin
+          key: darwin-${{ env.sha_short }}
+      - uses: actions/cache@v3
+        with:
+          path: dist/windows
+          key: windows-${{ env.sha_short }}
 
       - name: Log into Docker.io
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -53,11 +124,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+      - uses: goreleaser/goreleaser-action@v4
+        if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         with:
+          distribution: goreleaser-pro
           version: latest
-          args: release --rm-dist --timeout 2h
+          args: continue --merge --rm-dist --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: true
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
This attempts to split the prepare/release process using the example recommended here: https://goreleaser.com/customization/partial/. This may reduce the amount of time it takes to build the release and hopefully address disk space constraints.

Signed-off-by: Alex Boten <aboten@lightstep.com>