### PR TITLE
Add --fail option to curl when downloading builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq (, $(shell command -v ocb 2>/dev/null))
 	[ "$${machine}" != x86_64 ] || machine=amd64 ;\
 	echo "Installing ocb ($${os}/$${machine}) at $(OTELCOL_BUILDER_DIR)";\
 	mkdir -p $(OTELCOL_BUILDER_DIR) ;\
-	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OTELCOL_BUILDER_VERSION)/ocb_$(OTELCOL_BUILDER_VERSION)_$${os}_$${machine}" ;\
+	curl -sfLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OTELCOL_BUILDER_VERSION)/ocb_$(OTELCOL_BUILDER_VERSION)_$${os}_$${machine}" ;\
 	chmod +x $(OTELCOL_BUILDER) ;\
 	}
 else


### PR DESCRIPTION
This makes e.g. 404 errors much less confusing and would have helped in identifying open-telemetry/opentelemetry-collector/issues/6849 sooner (since otherwise the command passes and you get a plain text file that says `Not Found`)