### PR TITLE
fix: move loglevel configuration to verbosity

### DIFF
--- a/configs/otelcol-contrib.yaml
+++ b/configs/otelcol-contrib.yaml
@@ -36,7 +36,7 @@ processors:
 
 exporters:
   logging:
-    logLevel: debug
+    verbosity: detailed
 
 service:
 

--- a/configs/otelcol.yaml
+++ b/configs/otelcol.yaml
@@ -36,7 +36,7 @@ processors:
 
 exporters:
   logging:
-    logLevel: debug
+    verbosity: detailed
 
 service:
 


### PR DESCRIPTION
Current configuration for docker containers is broken:

```
Error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:

* error decoding 'exporters': error reading configuration for "logging": 1 error(s) decoding:

* '' has invalid keys: logLevel
2023/02/15 12:00:45 collector server run finished with error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:

* error decoding 'exporters': error reading configuration for "logging": 1 error(s) decoding:

* '' has invalid keys: logLevel
```


See: https://github.com/open-telemetry/opentelemetry-collector/commit/bdf63b77e33af2be3bc65e891c379f3a303f6e46
