### PR TITLE
Bump Go to 1.19.8 (security fixes in the standard library)

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.19.6'
+          go-version: '~1.19.8'
           check-latest: true
 
       - name: Generate the sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.19.6'
+          go-version: '~1.19.8'
           check-latest: true
 
       - name: Verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.19.6'
+          go-version: '~1.19.8'
           check-latest: true
 
       - name: Generate distribution sources
@@ -94,7 +94,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.19.6'
+          go-version: '~1.19.8'
           check-latest: true
 
       # copy the caches from prepare


### PR DESCRIPTION
This bumps the Go version a two patches up to include some security fixes in the standard library.

For more context, please see:
* https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20342