### PR TITLE
Add Dataset exporter to the contrib distribution

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -43,6 +43,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.77.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/f5cloudexporter v0.77.0


### PR DESCRIPTION
In this PR - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22154 - I have added the final PR.

Initial implementation was included in the release v0.77.0 - https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.77.0 - so it would be great if this exporter could be part of the official release v0.78.0.