### PR TITLE
[goreleaser] Switch from deprecated --rm-dist to --clean

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: --snapshot --rm-dist --skip-sign --skip-sbom --timeout 2h --split
+          args: --snapshot --clean --skip-sign --skip-sbom --timeout 2h --split
         env:
           GOOS: ${{ matrix.GOOS }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --rm-dist --split --timeout 2h
+          args: release --clean --split --timeout 2h
         env:
           GOOS: ${{ matrix.GOOS }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ generate-sources: go ocb
 	@./scripts/build.sh -d "${DISTRIBUTIONS}" -s true -b ${OTELCOL_BUILDER} -g ${GO}
 
 goreleaser-verify: goreleaser
-	@${GORELEASER} release --snapshot --rm-dist
+	@${GORELEASER} release --snapshot --clean
 
 ensure-goreleaser-up-to-date: generate-goreleaser
 	@git diff -s --exit-code .goreleaser.yaml || (echo "Build failed: The goreleaser templates have changed but the .goreleaser.yaml hasn't. Run 'make generate-goreleaser' and update your PR." && exit 1)


### PR DESCRIPTION
`--rm-dist` has been deprecated in favor of `--clean`, see https://goreleaser.com/deprecations/#-rm-dist