### PR TITLE
[chore] split goreleaser by GOARCH

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
+        GOARCH: ["386", amd64, arm64, ppc64le]
     runs-on: ubuntu-20.04
 
     steps:
@@ -53,4 +54,5 @@ jobs:
           args: --snapshot --clean --skip-sign --skip-sbom --timeout 2h --split
         env:
           GOOS: ${{ matrix.GOOS }}
+          GOARCH: ${{ matrix.GOARCH }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -21,6 +21,11 @@ jobs:
       matrix:
         GOOS: [linux, windows, darwin]
         GOARCH: ["386", amd64, arm64, ppc64le]
+        exclude:
+          - GOOS: darwin
+            GOARCH: "386"
+          - GOOS: windows
+            GOARCH: arm64
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
+        GOARCH: ["386", amd64, arm64, ppc64le]
     runs-on: ubuntu-20.04
 
     steps:
@@ -49,12 +50,6 @@ jobs:
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - id: cache
-        uses: actions/cache@v3
-        with:
-          path: dist/${{ matrix.GOOS }}
-          key: ${{ matrix.GOOS }}-${{ env.sha_short }}
-
       - uses: goreleaser/goreleaser-action@v4
         if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         with:
@@ -63,9 +58,15 @@ jobs:
           args: release --clean --split --timeout 2h
         env:
           GOOS: ${{ matrix.GOOS }}
+          GOARCH: ${{ matrix.GOARCH }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           COSIGN_EXPERIMENTAL: true
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: all-artifacts
+          path: dist/*/*
 
   release:
     name: Release
@@ -97,22 +98,10 @@ jobs:
           go-version: '~1.20.4'
           check-latest: true
 
-      # copy the caches from prepare
-      - shell: bash
-        run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/download-artifact@v3
         with:
-          path: dist/linux
-          key: linux-${{ env.sha_short }}
-      - uses: actions/cache@v3
-        with:
-          path: dist/darwin
-          key: darwin-${{ env.sha_short }}
-      - uses: actions/cache@v3
-        with:
-          path: dist/windows
-          key: windows-${{ env.sha_short }}
+          name: all-artifacts
+          path: dist
 
       - name: Log into Docker.io
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         GOOS: [linux, windows, darwin]
         GOARCH: ["386", amd64, arm64, ppc64le]
+        exclude:
+          - GOOS: darwin
+            GOARCH: "386"
+          - GOOS: windows
+            GOARCH: arm64
     runs-on: ubuntu-20.04
 
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,13 @@
 project_name: opentelemetry-collector-releases
+partial:
+  # By what you want to build the partial things.
+  #
+  # Valid options are `target` and `goos`:
+  # - `target`: `GOOS` + `GOARCH`.
+  # - `goos`: `GOOS` only
+  #
+  # Default: `goos`.
+  by: target
 builds:
     - id: otelcol
       goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,13 +1,4 @@
 project_name: opentelemetry-collector-releases
-partial:
-  # By what you want to build the partial things.
-  #
-  # Valid options are `target` and `goos`:
-  # - `target`: `GOOS` + `GOARCH`.
-  # - `goos`: `GOOS` only
-  #
-  # Default: `goos`.
-  by: target
 builds:
     - id: otelcol
       goos:


### PR DESCRIPTION
This is to address a space limit we've run into w/ caching. Additionally, I changed the workflow to use upload/download artifact to avoid having to create many copies of the cache action for each combination of GOOS+GOARCH.

Linked issue: https://github.com/open-telemetry/opentelemetry-collector-releases/issues/341

I tested the results of upload/download artifact in a private repository.