### PR TITLE
[chore] remove split by goarch

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -20,12 +20,6 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
-        GOARCH: ["386", amd64, arm64, ppc64le]
-        exclude:
-          - GOOS: darwin
-            GOARCH: "386"
-          - GOOS: windows
-            GOARCH: arm64
     runs-on: ubuntu-20.04
 
     steps:
@@ -59,5 +53,4 @@ jobs:
           args: --snapshot --clean --skip-sign --skip-sbom --timeout 2h --split
         env:
           GOOS: ${{ matrix.GOOS }}
-          GOARCH: ${{ matrix.GOARCH }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,6 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
-        GOARCH: ["386", amd64, arm64, ppc64le]
-        exclude:
-          - GOOS: darwin
-            GOARCH: "386"
-          - GOOS: windows
-            GOARCH: arm64
     runs-on: ubuntu-20.04
 
     steps:
@@ -63,7 +57,6 @@ jobs:
           args: release --clean --split --timeout 2h
         env:
           GOOS: ${{ matrix.GOOS }}
-          GOARCH: ${{ matrix.GOARCH }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           COSIGN_EXPERIMENTAL: true
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
The split by goarch doesn't work yet. The library used to generate the goreleaser config doesn't support partial configuration, which we would need to be able to use goarch as a parameter. See discussion https://github.com/orgs/goreleaser/discussions/4033#discussioncomment-6007074