### PR TITLE
Add arm32v7 to release configurations

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -20,12 +20,16 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
-        GOARCH: ["386", amd64, arm64, ppc64le]
+        GOARCH: ["386", amd64, arm64, ppc64le, arm]
         exclude:
           - GOOS: darwin
             GOARCH: "386"
           - GOOS: windows
             GOARCH: arm64
+          - GOOS: darwin
+            GOARCH: arm
+          - GOOS: windows
+            GOARCH: arm
     runs-on: ubuntu-20.04
 
     steps:
@@ -37,7 +41,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,ppc64le
+          platforms: arm64,ppc64le,linux/arm/v7
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,16 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
-        GOARCH: ["386", amd64, arm64, ppc64le]
+        GOARCH: ["386", amd64, arm64, ppc64le, arm]
         exclude:
           - GOOS: darwin
             GOARCH: "386"
           - GOOS: windows
             GOARCH: arm64
+          - GOOS: darwin
+            GOARCH: arm
+          - GOOS: windows
+            GOARCH: arm
     runs-on: ubuntu-20.04
 
     steps:
@@ -26,7 +30,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,ppc64le
+          platforms: arm64,ppc64le,linux/arm/v7
 
       - uses: docker/setup-buildx-action@v2
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,11 +10,16 @@ builds:
       goarch:
         - "386"
         - amd64
+        - arm
         - arm64
         - ppc64le
       ignore:
         - goos: darwin
           goarch: "386"
+        - goos: darwin
+          goarch: arm
+        - goos: windows
+          goarch: arm
         - goos: windows
           goarch: arm64
       dir: distributions/otelcol/_build
@@ -34,11 +39,16 @@ builds:
       goarch:
         - "386"
         - amd64
+        - arm
         - arm64
         - ppc64le
       ignore:
         - goos: darwin
           goarch: "386"
+        - goos: darwin
+          goarch: arm
+        - goos: windows
+          goarch: arm
         - goos: windows
           goarch: arm64
       dir: distributions/otelcol-contrib/_build
@@ -150,6 +160,25 @@ dockers:
         - --label=org.opencontainers.image.source={{.GitURL}}
       use: buildx
     - goos: linux
+      goarch: arm
+      dockerfile: distributions/otelcol/Dockerfile
+      image_templates:
+        - otel/opentelemetry-collector:{{ .Version }}-arm32v7
+        - otel/opentelemetry-collector:latest-arm32v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm32v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm32v7
+      extra_files:
+        - configs/otelcol.yaml
+      build_flag_templates:
+        - --pull
+        - --platform=linux/arm/v7
+        - --label=org.opencontainers.image.created={{.Date}}
+        - --label=org.opencontainers.image.name={{.ProjectName}}
+        - --label=org.opencontainers.image.revision={{.FullCommit}}
+        - --label=org.opencontainers.image.version={{.Version}}
+        - --label=org.opencontainers.image.source={{.GitURL}}
+      use: buildx
+    - goos: linux
       goarch: arm64
       dockerfile: distributions/otelcol/Dockerfile
       image_templates:
@@ -226,6 +255,25 @@ dockers:
         - --label=org.opencontainers.image.source={{.GitURL}}
       use: buildx
     - goos: linux
+      goarch: arm
+      dockerfile: distributions/otelcol-contrib/Dockerfile
+      image_templates:
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm32v7
+        - otel/opentelemetry-collector-contrib:latest-arm32v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm32v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm32v7
+      extra_files:
+        - configs/otelcol-contrib.yaml
+      build_flag_templates:
+        - --pull
+        - --platform=linux/arm/v7
+        - --label=org.opencontainers.image.created={{.Date}}
+        - --label=org.opencontainers.image.name={{.ProjectName}}
+        - --label=org.opencontainers.image.revision={{.FullCommit}}
+        - --label=org.opencontainers.image.version={{.Version}}
+        - --label=org.opencontainers.image.source={{.GitURL}}
+      use: buildx    
+    - goos: linux
       goarch: arm64
       dockerfile: distributions/otelcol-contrib/Dockerfile
       image_templates:
@@ -268,47 +316,55 @@ docker_manifests:
       image_templates:
         - otel/opentelemetry-collector:{{ .Version }}-386
         - otel/opentelemetry-collector:{{ .Version }}-amd64
+        - otel/opentelemetry-collector:{{ .Version }}-arm32v7
         - otel/opentelemetry-collector:{{ .Version }}-arm64
         - otel/opentelemetry-collector:{{ .Version }}-ppc64le
     - name_template: otel/opentelemetry-collector:latest
       image_templates:
         - otel/opentelemetry-collector:latest-386
         - otel/opentelemetry-collector:latest-amd64
+        - otel/opentelemetry-collector:latest-arm32v7
         - otel/opentelemetry-collector:latest-arm64
         - otel/opentelemetry-collector:latest-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm32v7        
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm32v7        
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - otel/opentelemetry-collector-contrib:{{ .Version }}-386
         - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm32v7        
         - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
     - name_template: otel/opentelemetry-collector-contrib:latest
       image_templates:
         - otel/opentelemetry-collector-contrib:latest-386
         - otel/opentelemetry-collector-contrib:latest-amd64
+        - otel/opentelemetry-collector-contrib:latest-arm32v7        
         - otel/opentelemetry-collector-contrib:latest-arm64
         - otel/opentelemetry-collector-contrib:latest-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm32v7        
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm32v7        
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -168,10 +168,10 @@ dockers:
       goarm: "7"
       dockerfile: distributions/otelcol/Dockerfile
       image_templates:
-        - otel/opentelemetry-collector:{{ .Version }}-arm/v7
-        - otel/opentelemetry-collector:latest-arm/v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm/v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm/v7
+        - otel/opentelemetry-collector:{{ .Version }}-armv7
+        - otel/opentelemetry-collector:latest-armv7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
       extra_files:
         - configs/otelcol.yaml
       build_flag_templates:
@@ -264,10 +264,10 @@ dockers:
       goarm: "7"
       dockerfile: distributions/otelcol-contrib/Dockerfile
       image_templates:
-        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
-        - otel/opentelemetry-collector-contrib:latest-arm/v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm/v7
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
+        - otel/opentelemetry-collector-contrib:latest-armv7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
       extra_files:
         - configs/otelcol-contrib.yaml
       build_flag_templates:
@@ -322,55 +322,55 @@ docker_manifests:
       image_templates:
         - otel/opentelemetry-collector:{{ .Version }}-386
         - otel/opentelemetry-collector:{{ .Version }}-amd64
-        - otel/opentelemetry-collector:{{ .Version }}-arm/v7
+        - otel/opentelemetry-collector:{{ .Version }}-armv7
         - otel/opentelemetry-collector:{{ .Version }}-arm64
         - otel/opentelemetry-collector:{{ .Version }}-ppc64le
     - name_template: otel/opentelemetry-collector:latest
       image_templates:
         - otel/opentelemetry-collector:latest-386
         - otel/opentelemetry-collector:latest-amd64
-        - otel/opentelemetry-collector:latest-arm/v7
+        - otel/opentelemetry-collector:latest-armv7
         - otel/opentelemetry-collector:latest-arm64
         - otel/opentelemetry-collector:latest-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - otel/opentelemetry-collector-contrib:{{ .Version }}-386
         - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
         - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
     - name_template: otel/opentelemetry-collector-contrib:latest
       image_templates:
         - otel/opentelemetry-collector-contrib:latest-386
         - otel/opentelemetry-collector-contrib:latest-amd64
-        - otel/opentelemetry-collector-contrib:latest-arm/v7
+        - otel/opentelemetry-collector-contrib:latest-armv7
         - otel/opentelemetry-collector-contrib:latest-arm64
         - otel/opentelemetry-collector-contrib:latest-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,8 @@ builds:
         - arm
         - arm64
         - ppc64le
+      goarm:
+        - "7"
       ignore:
         - goos: darwin
           goarch: "386"
@@ -42,6 +44,8 @@ builds:
         - arm
         - arm64
         - ppc64le
+      goarm:
+        - "7"
       ignore:
         - goos: darwin
           goarch: "386"
@@ -161,12 +165,13 @@ dockers:
       use: buildx
     - goos: linux
       goarch: arm
+      goarm: "7"
       dockerfile: distributions/otelcol/Dockerfile
       image_templates:
-        - otel/opentelemetry-collector:{{ .Version }}-arm32v7
-        - otel/opentelemetry-collector:latest-arm32v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm32v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm32v7
+        - otel/opentelemetry-collector:{{ .Version }}-arm/v7
+        - otel/opentelemetry-collector:latest-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm/v7
       extra_files:
         - configs/otelcol.yaml
       build_flag_templates:
@@ -256,12 +261,13 @@ dockers:
       use: buildx
     - goos: linux
       goarch: arm
+      goarm: "7"
       dockerfile: distributions/otelcol-contrib/Dockerfile
       image_templates:
-        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm32v7
-        - otel/opentelemetry-collector-contrib:latest-arm32v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm32v7
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm32v7
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
+        - otel/opentelemetry-collector-contrib:latest-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm/v7
       extra_files:
         - configs/otelcol-contrib.yaml
       build_flag_templates:
@@ -272,7 +278,7 @@ dockers:
         - --label=org.opencontainers.image.revision={{.FullCommit}}
         - --label=org.opencontainers.image.version={{.Version}}
         - --label=org.opencontainers.image.source={{.GitURL}}
-      use: buildx    
+      use: buildx
     - goos: linux
       goarch: arm64
       dockerfile: distributions/otelcol-contrib/Dockerfile
@@ -316,55 +322,55 @@ docker_manifests:
       image_templates:
         - otel/opentelemetry-collector:{{ .Version }}-386
         - otel/opentelemetry-collector:{{ .Version }}-amd64
-        - otel/opentelemetry-collector:{{ .Version }}-arm32v7
+        - otel/opentelemetry-collector:{{ .Version }}-arm/v7
         - otel/opentelemetry-collector:{{ .Version }}-arm64
         - otel/opentelemetry-collector:{{ .Version }}-ppc64le
     - name_template: otel/opentelemetry-collector:latest
       image_templates:
         - otel/opentelemetry-collector:latest-386
         - otel/opentelemetry-collector:latest-amd64
-        - otel/opentelemetry-collector:latest-arm32v7
+        - otel/opentelemetry-collector:latest-arm/v7
         - otel/opentelemetry-collector:latest-arm64
         - otel/opentelemetry-collector:latest-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm32v7        
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm/v7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm32v7        
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm/v7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - otel/opentelemetry-collector-contrib:{{ .Version }}-386
         - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm32v7        
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
         - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
     - name_template: otel/opentelemetry-collector-contrib:latest
       image_templates:
         - otel/opentelemetry-collector-contrib:latest-386
         - otel/opentelemetry-collector-contrib:latest-amd64
-        - otel/opentelemetry-collector-contrib:latest-arm32v7        
+        - otel/opentelemetry-collector-contrib:latest-arm/v7
         - otel/opentelemetry-collector-contrib:latest-arm64
         - otel/opentelemetry-collector-contrib:latest-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm32v7        
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm/v7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
-        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm32v7        
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm/v7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ make goreleaser-verify
 
 #### Building multi-architecture Docker images
 
-goreleaser will build Docker images for x86_64 and arm64 processors. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
+goreleaser will build Docker images for x86_64, 386, arm, arm64 and ppc64le processors. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
 
 This is accomplished by installing [qemu](https://www.qemu.org/), and then [enabling support](https://github.com/multiarch/qemu-user-static#readme) for qemu within Docker:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository assembles OpenTelemetry Collector distributions, such as the "co
 Each distribution contains:
 
 - Binaries for a multitude of platforms and architectures
-- Multi-arch container images (x86_64 and arm64)
+- Multi-arch container images (x86_64, 386, arm, arm64 and ppc64le)
 - Packages to be used with Linux distributions (apk, RPM, deb), Mac OS (brew)
 
 More details about each individual distribution can be seen in its own readme files.

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -167,10 +167,11 @@ func DockerImage(imagePrefixes []string, dist, arch, armVersion string) config.D
 	dockerArchName := archName(arch, armVersion)
 	var imageTemplates []string
 	for _, prefix := range imagePrefixes {
+		dockerArchTag := strings.ReplaceAll(dockerArchName, "/", "")
 		imageTemplates = append(
 			imageTemplates,
-			fmt.Sprintf("%s/%s:{{ .Version }}-%s", prefix, imageName(dist), dockerArchName),
-			fmt.Sprintf("%s/%s:latest-%s", prefix, imageName(dist), dockerArchName),
+			fmt.Sprintf("%s/%s:{{ .Version }}-%s", prefix, imageName(dist), dockerArchTag),
+			fmt.Sprintf("%s/%s:latest-%s", prefix, imageName(dist), dockerArchTag),
 		)
 	}
 
@@ -217,9 +218,10 @@ func DockerManifest(prefix, version, dist string) config.DockerManifest {
 		switch arch {
 		case ArmArch:
 			for _, armVers := range ArmVersions {
+				dockerArchTag := strings.ReplaceAll(archName(arch, armVers), "/", "")
 				imageTemplates = append(
 					imageTemplates,
-					fmt.Sprintf("%s/%s:%s-%s", prefix, imageName(dist), version, archName(arch, armVers)),
+					fmt.Sprintf("%s/%s:%s-%s", prefix, imageName(dist), version, dockerArchTag),
 				)
 			}
 		default:

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	ImagePrefixes = []string{"otel", "ghcr.io/open-telemetry/opentelemetry-collector-releases"}
-	Architectures = []string{"386", "amd64", "arm64", "ppc64le"}
+	Architectures = []string{"386", "amd64", "arm", "arm64", "ppc64le"}
 )
 
 func Generate(imagePrefixes []string, dists []string) config.Project {
@@ -71,6 +71,8 @@ func Build(dist string) config.Build {
 		Goarch: Architectures,
 		Ignore: []config.IgnoredBuild{
 			{Goos: "darwin", Goarch: "386"},
+			{Goos: "darwin", Goarch: "arm"},
+			{Goos: "windows", Goarch: "arm"},
 			{Goos: "windows", Goarch: "arm64"},
 		},
 	}


### PR DESCRIPTION
### Summary

This pull request is looking to introduce arm32v7 release for otelcol and otel-contrib distribution. 

The pull request builds on top of the changes in https://github.com/open-telemetry/opentelemetry-collector-releases/pull/146, I changed `--platform` to `linux/arm/v7` to hopefully fix the CI build error. 

### Manual Tests

- [x] Able to build the new arm docker image locally with `goreleaser release --clean --snapshot`