### PR TITLE
Add support for linux/s390x architecture

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -20,16 +20,20 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
-        GOARCH: ["386", amd64, arm64, ppc64le, arm]
+        GOARCH: ["386", amd64, arm64, ppc64le, arm, s390x]
         exclude:
           - GOOS: darwin
             GOARCH: "386"
+          - GOOS: darwin
+            GOARCH: s390x
           - GOOS: windows
             GOARCH: arm64
           - GOOS: darwin
             GOARCH: arm
           - GOOS: windows
             GOARCH: arm
+          - GOOS: windows
+            GOARCH: s390x
     runs-on: ubuntu-20.04
 
     steps:
@@ -41,7 +45,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,ppc64le,linux/arm/v7
+          platforms: arm64,ppc64le,linux/arm/v7,s390x
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,16 +9,20 @@ jobs:
     strategy:
       matrix:
         GOOS: [linux, windows, darwin]
-        GOARCH: ["386", amd64, arm64, ppc64le, arm]
+        GOARCH: ["386", amd64, arm64, ppc64le, arm, s390x]
         exclude:
           - GOOS: darwin
             GOARCH: "386"
+          - GOOS: darwin
+            GOARCH: s390x
           - GOOS: windows
             GOARCH: arm64
           - GOOS: darwin
             GOARCH: arm
           - GOOS: windows
             GOARCH: arm
+          - GOOS: windows
+            GOARCH: s390x
     runs-on: ubuntu-20.04
 
     steps:
@@ -30,7 +34,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,ppc64le,linux/arm/v7
+          platforms: arm64,ppc64le,linux/arm/v7,s390x
 
       - uses: docker/setup-buildx-action@v2
 
@@ -98,7 +102,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,ppc64le
+          platforms: arm64,ppc64le,s390x
 
       - uses: docker/setup-buildx-action@v2
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
         - arm
         - arm64
         - ppc64le
+        - s390x
       goarm:
         - "7"
       ignore:
@@ -20,10 +21,14 @@ builds:
           goarch: "386"
         - goos: darwin
           goarch: arm
+        - goos: darwin
+          goarch: s390x
         - goos: windows
           goarch: arm
         - goos: windows
           goarch: arm64
+        - goos: windows
+          goarch: s390x
       dir: distributions/otelcol/_build
       binary: otelcol
       ldflags:
@@ -44,6 +49,7 @@ builds:
         - arm
         - arm64
         - ppc64le
+        - s390x
       goarm:
         - "7"
       ignore:
@@ -51,10 +57,14 @@ builds:
           goarch: "386"
         - goos: darwin
           goarch: arm
+        - goos: darwin
+          goarch: s390x
         - goos: windows
           goarch: arm
         - goos: windows
           goarch: arm64
+        - goos: windows
+          goarch: s390x
       dir: distributions/otelcol-contrib/_build
       binary: otelcol-contrib
       ldflags:
@@ -222,6 +232,25 @@ dockers:
         - --label=org.opencontainers.image.source={{.GitURL}}
       use: buildx
     - goos: linux
+      goarch: s390x
+      dockerfile: distributions/otelcol/Dockerfile
+      image_templates:
+        - otel/opentelemetry-collector:{{ .Version }}-s390x
+        - otel/opentelemetry-collector:latest-s390x
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      extra_files:
+        - configs/otelcol.yaml
+      build_flag_templates:
+        - --pull
+        - --platform=linux/s390x
+        - --label=org.opencontainers.image.created={{.Date}}
+        - --label=org.opencontainers.image.name={{.ProjectName}}
+        - --label=org.opencontainers.image.revision={{.FullCommit}}
+        - --label=org.opencontainers.image.version={{.Version}}
+        - --label=org.opencontainers.image.source={{.GitURL}}
+      use: buildx
+    - goos: linux
       goarch: "386"
       dockerfile: distributions/otelcol-contrib/Dockerfile
       image_templates:
@@ -317,6 +346,25 @@ dockers:
         - --label=org.opencontainers.image.version={{.Version}}
         - --label=org.opencontainers.image.source={{.GitURL}}
       use: buildx
+    - goos: linux
+      goarch: s390x
+      dockerfile: distributions/otelcol-contrib/Dockerfile
+      image_templates:
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
+        - otel/opentelemetry-collector-contrib:latest-s390x
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      extra_files:
+        - configs/otelcol-contrib.yaml
+      build_flag_templates:
+        - --pull
+        - --platform=linux/s390x
+        - --label=org.opencontainers.image.created={{.Date}}
+        - --label=org.opencontainers.image.name={{.ProjectName}}
+        - --label=org.opencontainers.image.revision={{.FullCommit}}
+        - --label=org.opencontainers.image.version={{.Version}}
+        - --label=org.opencontainers.image.source={{.GitURL}}
+      use: buildx
 docker_manifests:
     - name_template: otel/opentelemetry-collector:{{ .Version }}
       image_templates:
@@ -325,6 +373,7 @@ docker_manifests:
         - otel/opentelemetry-collector:{{ .Version }}-armv7
         - otel/opentelemetry-collector:{{ .Version }}-arm64
         - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+        - otel/opentelemetry-collector:{{ .Version }}-s390x
     - name_template: otel/opentelemetry-collector:latest
       image_templates:
         - otel/opentelemetry-collector:latest-386
@@ -332,6 +381,7 @@ docker_manifests:
         - otel/opentelemetry-collector:latest-armv7
         - otel/opentelemetry-collector:latest-arm64
         - otel/opentelemetry-collector:latest-ppc64le
+        - otel/opentelemetry-collector:latest-s390x
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
@@ -339,6 +389,7 @@ docker_manifests:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
@@ -346,6 +397,7 @@ docker_manifests:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
     - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - otel/opentelemetry-collector-contrib:{{ .Version }}-386
@@ -353,6 +405,7 @@ docker_manifests:
         - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
         - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+        - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
     - name_template: otel/opentelemetry-collector-contrib:latest
       image_templates:
         - otel/opentelemetry-collector-contrib:latest-386
@@ -360,6 +413,7 @@ docker_manifests:
         - otel/opentelemetry-collector-contrib:latest-armv7
         - otel/opentelemetry-collector-contrib:latest-arm64
         - otel/opentelemetry-collector-contrib:latest-ppc64le
+        - otel/opentelemetry-collector-contrib:latest-s390x
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
@@ -367,6 +421,7 @@ docker_manifests:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
     - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
       image_templates:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
@@ -374,3 +429,4 @@ docker_manifests:
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
         - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+        - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -32,7 +32,7 @@ const ArmArch = "arm"
 
 var (
 	ImagePrefixes = []string{"otel", "ghcr.io/open-telemetry/opentelemetry-collector-releases"}
-	Architectures = []string{"386", "amd64", "arm", "arm64", "ppc64le"}
+	Architectures = []string{"386", "amd64", "arm", "arm64", "ppc64le", "s390x"}
 	ArmVersions   = []string{"7"}
 )
 
@@ -76,8 +76,10 @@ func Build(dist string) config.Build {
 		Ignore: []config.IgnoredBuild{
 			{Goos: "darwin", Goarch: "386"},
 			{Goos: "darwin", Goarch: "arm"},
+			{Goos: "darwin", Goarch: "s390x"},
 			{Goos: "windows", Goarch: "arm"},
 			{Goos: "windows", Goarch: "arm64"},
+			{Goos: "windows", Goarch: "s390x"},
 		},
 	}
 }


### PR DESCRIPTION
The `s390x` CPU architecture is the base for IBM zSeries (aka mainframe) systems. It is beneficial for users of this platform to have a supported way to install pre-compiled binaries for the OpenTelemetry collector in a Linux environment. This issue and associated pull requests will enable the building of all relevant binary artifacts for `linux/s390x` as part of the regular CI pipeline.

IBM has performed tests internally to ensure successful build (via cross-compilation) and runtime (on native platform) integrity of the OpenTelemetry collector (core and contrib) via the unit test suites and specific use-cases.

For more information and discussion please refer to the initial feature request issue (open-telemetry/opentelemetry-collector-releases#378).