### PR TITLE
Adding Datadog Connector

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -197,6 +197,7 @@ receivers:
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.83.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.83.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.83.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.83.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.83.0
 


### PR DESCRIPTION
The Datadog Processor is deprecated in favor of the Datadog Connector. This PR adds the connector to the build.

Link to issue: [19740](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19740)
Link to connector: [Datadog Connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector)