### PR TITLE
[chore] Update go versions used in workflows

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.21'
+          go-version: '~1.21.1'
           check-latest: true
 
       - name: Generate the sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.21'
+          go-version: '~1.21.1'
           check-latest: true
 
       - name: Verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.21'
+          go-version: '~1.21.1'
           check-latest: true
 
       - name: Generate distribution sources
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.21'
+          go-version: '~1.21.1'
           check-latest: true
 
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This is a defensive PR to update the go versions to force a minimum version. The latest patch versions contains security related fixes. 