### PR TITLE
add debug exporter and switch logging exporter

### DIFF
--- a/configs/otelcol-contrib.yaml
+++ b/configs/otelcol-contrib.yaml
@@ -35,7 +35,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
@@ -45,11 +45,11 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
     metrics:
       receivers: [otlp, opencensus, prometheus]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [health_check, pprof, zpages]

--- a/configs/otelcol.yaml
+++ b/configs/otelcol.yaml
@@ -35,7 +35,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
@@ -45,11 +45,11 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
     metrics:
       receivers: [otlp, opencensus, prometheus]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [health_check, pprof, zpages]

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -32,6 +32,7 @@ extensions:
     import: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
 
 exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.85.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.85.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.85.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.85.0

--- a/distributions/otelcol/manifest.yaml
+++ b/distributions/otelcol/manifest.yaml
@@ -16,6 +16,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.85.0
 
 exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.85.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.85.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.85.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.85.0


### PR DESCRIPTION
Once the debug exporter is available, we'll want to switch to using it instead of the deprecated logging exporter.

Note: this PR will fail CI until the release of the debug exporter