### PR TITLE
Explicitly set 0.0.0.0 on sample configurations

### DIFF
--- a/configs/otelcol-contrib.yaml
+++ b/configs/otelcol-contrib.yaml
@@ -1,5 +1,4 @@
-# To limit exposure to denial of service attacks,
-# consider changing the host IP on servers from 0.0.0.0 to a specific network interface.
+# To limit exposure to denial of service attacks, change the host in endpoints below from 0.0.0.0 to a specific network interface.
 # See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
 
 extensions:

--- a/configs/otelcol-contrib.yaml
+++ b/configs/otelcol-contrib.yaml
@@ -1,3 +1,7 @@
+# To limit exposure to denial of service attacks,
+# consider changing the host IP on servers from 0.0.0.0 to a specific network interface.
+# See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
+
 extensions:
   health_check:
   pprof:
@@ -9,9 +13,12 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
   opencensus:
+    endpoint: 0.0.0.0:55678
 
   # Collect own metrics
   prometheus:
@@ -25,11 +32,16 @@ receivers:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
 
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:

--- a/configs/otelcol.yaml
+++ b/configs/otelcol.yaml
@@ -1,5 +1,4 @@
-# To limit exposure to denial of service attacks,
-# consider changing the host IP on servers from 0.0.0.0 to a specific network interface.
+# To limit exposure to denial of service attacks, change the host in endpoints below from 0.0.0.0 to a specific network interface.
 # See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
 
 extensions:

--- a/configs/otelcol.yaml
+++ b/configs/otelcol.yaml
@@ -1,3 +1,7 @@
+# To limit exposure to denial of service attacks,
+# consider changing the host IP on servers from 0.0.0.0 to a specific network interface.
+# See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
+
 extensions:
   health_check:
   pprof:
@@ -9,9 +13,12 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
   opencensus:
+    endpoint: 0.0.0.0:55678
 
   # Collect own metrics
   prometheus:
@@ -25,11 +32,16 @@ receivers:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
 
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:


### PR DESCRIPTION
Explicitly set `0.0.0.0` on the sample configurations so that if we make changes to the defaults Docker users are not affected immediately.

Recommend setting a specific network interface instead of 0.0.0.0 on a comment.

This does not change the behavior since the values set as endpoints are the current defaults.