### PR TITLE
Revert "Replace datadog-agent dependecy versions"

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -211,6 +211,3 @@ replaces:
   - github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
   # see https://github.com/openshift/api/pull/1515
   - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
-  # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25119
-  - github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
-  - github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-releases#386

Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27601.