### PR TITLE
[chore] bump go versions

### DIFF
--- a/.github/workflows/ci-goreleaser.yaml
+++ b/.github/workflows/ci-goreleaser.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.3'
           check-latest: true
 
       - name: Generate the sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.3'
           check-latest: true
 
       - name: Verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.3'
           check-latest: true
 
       - name: Generate distribution sources
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.3'
           check-latest: true
 
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This addresses https://pkg.go.dev/vuln/GO-2023-2102