### PR TITLE
[contrib] fix unknown connector `exceptions`

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -203,6 +203,7 @@ connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.92.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.92.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.92.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector v0.92.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:


### PR DESCRIPTION
```bash
│ * error decoding 'connectors': unknown type: "exceptions" for id: "exceptions" (valid values: [datadog routing servicegraph spanmetrics forward count])
│ 2024/01/10 09:34:12 collector server run finished with error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:
```