### PR TITLE
update default template with debug exporter

### DIFF
--- a/configs/otelcol-contrib.yaml
+++ b/configs/otelcol-contrib.yaml
@@ -46,7 +46,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
@@ -56,11 +56,11 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
     metrics:
       receivers: [otlp, opencensus, prometheus]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [health_check, pprof, zpages]

--- a/configs/otelcol.yaml
+++ b/configs/otelcol.yaml
@@ -46,7 +46,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
@@ -56,11 +56,11 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
     metrics:
       receivers: [otlp, opencensus, prometheus]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [health_check, pprof, zpages]


### PR DESCRIPTION
This should have been updated some versions ago, the logging exporter is now named debug exporter.