### PR TITLE
GoReleaser: publish Homebrew formula to a Tap on each new release

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -51,6 +51,21 @@ func Generate(dist string) config.Project {
 		Signs:           Sign(),
 		DockerSigns:     DockerSigns(),
 		SBOMs:           SBOM(),
+		Brews: []config.Homebrew{
+			{
+				Name:        dist,
+				Description: Description(dist),
+				Homepage:    "https://opentelemetry.io/docs/collector/",
+				License:     "Apache-2.0",
+				IDs: []string{
+					dist,
+				},
+				Repository: config.RepoRef{
+					Owner: "open-telemetry",
+					Name:  "homebrew-tap",
+				},
+			},
+		},
 	}
 }
 
@@ -295,5 +310,16 @@ func SBOM() []config.SBOM {
 			ID:        "package",
 			Artifacts: "package",
 		},
+	}
+}
+
+func Description(dist string) string {
+	switch dist {
+	case "otelcol":
+		return "OpenTelemetry collector distribution containing only core components"
+	case "otelcol-contrib":
+		return "OpenTelemetry collector distribution containing both core and contrib components"
+	default:
+		return ""
 	}
 }

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -249,3 +249,13 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
+brews:
+  - name: otelcol-contrib
+    description: "OpenTelemtry collector distribution containing only core components"
+    homepage: "https://opentelemetry.io/docs/collector/"
+    license: "Apache-2.0"
+    ids:
+      - otelcol-contrib
+    repository:
+      owner: open-telemetry
+      name: homebrew-tap

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -3,6 +3,16 @@ partial:
 project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
+brews:
+  - name: otelcol-contrib
+    repository:
+      owner: open-telemetry
+      name: homebrew-tap
+    description: OpenTelemetry collector distribution containing both core and contrib components
+    homepage: https://opentelemetry.io/docs/collector/
+    license: Apache-2.0
+    ids:
+      - otelcol-contrib
 builds:
   - id: otelcol-contrib
     goos:
@@ -249,13 +259,3 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
-brews:
-  - name: otelcol-contrib
-    description: "OpenTelemetry collector distribution containing only core components"
-    homepage: "https://opentelemetry.io/docs/collector/"
-    license: "Apache-2.0"
-    ids:
-      - otelcol-contrib
-    repository:
-      owner: open-telemetry
-      name: homebrew-tap

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -251,7 +251,7 @@ sboms:
     artifacts: package
 brews:
   - name: otelcol-contrib
-    description: "OpenTelemtry collector distribution containing only core components"
+    description: "OpenTelemetry collector distribution containing only core components"
     homepage: "https://opentelemetry.io/docs/collector/"
     license: "Apache-2.0"
     ids:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -3,6 +3,16 @@ partial:
 project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
+brews:
+  - name: otelcol
+    repository:
+      owner: open-telemetry
+      name: homebrew-tap
+    description: OpenTelemetry collector distribution containing only core components
+    homepage: https://opentelemetry.io/docs/collector/
+    license: Apache-2.0
+    ids:
+      - otelcol
 builds:
   - id: otelcol
     goos:
@@ -249,13 +259,3 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
-brews:
-  - name: otelcol
-    description: "OpenTelemetry collector distribution containing both core and contrib components"
-    homepage: "https://opentelemetry.io/docs/collector/"
-    license: "Apache-2.0"
-    ids:
-      - otelcol
-    repository:
-      owner: open-telemetry
-      name: homebrew-tap

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -249,3 +249,13 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
+brews:
+  - name: otelcol
+    description: "OpenTelemtry collector distribution containing both core and contrib components"
+    homepage: "https://opentelemetry.io/docs/collector/"
+    license: "Apache-2.0"
+    ids:
+      - otelcol
+    repository:
+      owner: open-telemetry
+      name: homebrew-tap

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -251,7 +251,7 @@ sboms:
     artifacts: package
 brews:
   - name: otelcol
-    description: "OpenTelemtry collector distribution containing both core and contrib components"
+    description: "OpenTelemetry collector distribution containing both core and contrib components"
     homepage: "https://opentelemetry.io/docs/collector/"
     license: "Apache-2.0"
     ids:


### PR DESCRIPTION
Currently installing OpenTelemetry Collector on macOS is pretty painful compared to Grafana Agent, see https://github.com/open-telemetry/opentelemetry-collector/issues/7891.

However, publishing a formula to a [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) can be intimidating both for the maintainers and consumers:

* maintainers: need a tooling to automatically publish new versions ([Grafana has a bot](https://github.com/Homebrew/homebrew-core/pull/155035) for this) or resort to manual work
* consumers: need to build from source, which takes a lot of time and CPU resources on target machines

A simpler, self-managed and readily available alternative is a [Homebrew Tap](https://docs.brew.sh/Taps).

Since OpenTelemetry already uses GoReleaser, and GoReleaser has a [Homebrew Taps](https://goreleaser.com/customization/homebrew/) module, publishing a Tap becomes a no-brainer (see PR diff for a minimally working implementation).

Installing from a Tap is as simple as:

```
brew install open-telemetry/tap/otelcol-contrib
```

Requires [open-telemetry/homebrew-tap](https://github.com/open-telemetry/homebrew-tap) repository to be created and accessible via `GITHUB_TOKEN`.

Cc: @svrnm, @jpeach