### PR TITLE
[chore] Add namedpipe receiver

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -158,6 +158,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.93.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.93.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.93.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver v0.93.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.93.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver v0.93.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.93.0


### PR DESCRIPTION
The [namedpipereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/namedpipereceiver) is currently marked as `Alpha` stability for `logs`, and shows itself as being included in `contrib`. Adding to release for parity.