### PR TITLE
Remove --id from continue command

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -137,7 +137,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: continue --merge --timeout 2h --id ${{ inputs.distribution }}
+          args: continue --merge --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_YES: true


### PR DESCRIPTION
The `goreleaser continue` command does not accept `--id` as a parameter.  It should use the result of the previous `release --clean --split --timeout 2h --id ${{ inputs.distribution }}` command which only built/prepped the id we care about.