### PR TITLE
[chore] update generate-goreleaser to generate distribution goreleaser files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: go ocb
 generate: generate-sources generate-goreleaser
 
 generate-goreleaser: go
-	@${GO} run cmd/goreleaser/main.go -d "${DISTRIBUTIONS}" > .goreleaser.yaml
+	@./scripts/generate-goreleaser.sh -d "${DISTRIBUTIONS}" -g ${GO}
 
 generate-sources: go ocb
 	@./scripts/build.sh -d "${DISTRIBUTIONS}" -s true -b ${OTELCOL_BUILDER} -g ${GO}
@@ -25,7 +25,7 @@ goreleaser-verify: goreleaser
 	@${GORELEASER} release --snapshot --clean
 
 ensure-goreleaser-up-to-date: generate-goreleaser
-	@git diff -s --exit-code .goreleaser.yaml || (echo "Build failed: The goreleaser templates have changed but the .goreleaser.yaml hasn't. Run 'make generate-goreleaser' and update your PR." && exit 0)
+	@git diff -s --exit-code distributions/*/.goreleaser.yaml || (echo "Build failed: The goreleaser templates have changed but the .goreleaser.yamls haven't. Run 'make generate-goreleaser' and update your PR." && exit 0)
 
 .PHONY: ocb
 ocb:

--- a/cmd/goreleaser/main.go
+++ b/cmd/goreleaser/main.go
@@ -18,24 +18,22 @@ import (
 	"flag"
 	"log"
 	"os"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-collector-releases/cmd/goreleaser/internal"
 )
 
-var distsFlag = flag.String("d", "", "Collector distributions(s) to build, comma-separated")
+var distFlag = flag.String("d", "", "Collector distributions to build")
 
 func main() {
 	flag.Parse()
 
-	if len(*distsFlag) == 0 {
-		log.Fatal("no distributions to build")
+	if len(*distFlag) == 0 {
+		log.Fatal("no distribution to build")
 	}
-	dists := strings.Split(*distsFlag, ",")
 
-	project := internal.Generate(internal.ImagePrefixes, dists)
+	project := internal.Generate(*distFlag)
 
 	partial := map[string]any{
 		"partial": map[string]any{
@@ -48,7 +46,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := yaml.NewEncoder(os.Stdout).Encode(&project); err != nil {
+	e = yaml.NewEncoder(os.Stdout)
+	e.SetIndent(2)
+	if err := e.Encode(&project); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/scripts/generate-goreleaser.sh
+++ b/scripts/generate-goreleaser.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+GO=''
+
+while getopts d:g: flag
+do
+    case "${flag}" in
+        d) distributions=${OPTARG};;
+        g) GO=${OPTARG};;
+        *) exit 1;;
+    esac
+done
+
+[[ -n "$GO" ]] || GO='go'
+
+if [[ -z $distributions ]]; then
+    echo "List of distributions to generate the goreleaser not provided. Use '-d' to specify the names of the distributions use. Ex.:"
+    echo "$0 -d otelcol"
+    exit 1
+fi
+
+echo "Distributions to generate: $distributions";
+
+for distribution in $(echo "$distributions" | tr "," "\n")
+do
+    ${GO} run cmd/goreleaser/main.go -d "${distribution}" > "./distributions/${distribution}/.goreleaser.yaml"
+done


### PR DESCRIPTION
This PR updates the `make generate-goreleaser` command to generate the `.goreleaser.yaml` files in all distributions.