### PR TITLE
[rpm/configfile] change behaviour  when upgrading the package 

### DIFF
--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -55,7 +55,7 @@ nfpms:
         type: config|noreplace
       - src: config.yaml
         dst: /etc/otelcol-contrib/config.yaml
-        type: config
+        type: config|noreplace
     scripts:
       preinstall: preinstall.sh
       postinstall: postinstall.sh

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -55,7 +55,7 @@ nfpms:
         type: config|noreplace
       - src: config.yaml
         dst: /etc/otelcol/config.yaml
-        type: config
+        type: config|noreplace
     scripts:
       preinstall: preinstall.sh
       postinstall: postinstall.sh


### PR DESCRIPTION
This patch changes the behaviour of how to manage the config file /etc/otelcol-contrib/config.yaml .
It now keeps the existing config file in place and puts the new file as a config.yaml.rpmnew 

```
rpm -vUh otelcol-contrib_0.96.0_linux_amd64.rpm
Verifying... ################################# [100%]
Preparing... ################################# [100%]
Updating / installing...
1:otelcol-contrib-0:0.96.0-1 warning: /etc/otelcol-contrib/config.yaml created as /etc/otelcol-contrib/config.yaml.rpmnew
```


This would fix https://github.com/open-telemetry/opentelemetry-collector-releases/issues/502 