### PR TITLE
[chore] Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ goreleaser-verify: goreleaser
 	@${GORELEASER} release --snapshot --clean
 
 ensure-goreleaser-up-to-date: generate-goreleaser
-	@git diff -s --exit-code distributions/*/.goreleaser.yaml || (echo "Build failed: The goreleaser templates have changed but the .goreleaser.yamls haven't. Run 'make generate-goreleaser' and update your PR." && exit 0)
+	@git diff -s --exit-code distributions/*/.goreleaser.yaml || (echo "Check failed: The goreleaser templates have changed but the .goreleaser.yamls haven't. Run 'make generate-goreleaser' and update your PR." && exit 1)
 
 .PHONY: ocb
 ocb:

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -140,7 +140,7 @@ func Package(dist string) config.NFPM {
 				{
 					Source:      "config.yaml",
 					Destination: path.Join("/etc", dist, "config.yaml"),
-					Type:        "config",
+					Type:        "config|noreplace",
 				},
 			},
 		},


### PR DESCRIPTION
I noticed that the CI workflow wasn't accurately failing when the goreleaser files were out-of-date with the generated code.  Main is actually broken right now.