### PR TITLE
Add nop components to core and contrib

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -33,6 +33,7 @@ extensions:
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.97.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.97.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.97.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.97.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.97.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.97.0
@@ -103,6 +104,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.97.0
 
 receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.97.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.97.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.97.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.97.0

--- a/distributions/otelcol/manifest.yaml
+++ b/distributions/otelcol/manifest.yaml
@@ -7,6 +7,7 @@ dist:
   otelcol_version: 0.97.0
 
 receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.97.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.97.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.97.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.97.0
@@ -18,6 +19,7 @@ receivers:
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.97.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.97.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.97.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.97.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.97.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.97.0


### PR DESCRIPTION
Adds the nop components that were released in 0.97.0.

Related to https://github.com/open-telemetry/opentelemetry-collector/issues/7316.