### PR TITLE
update remaining goreleaser usages to v2

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -24,7 +24,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/goreleaser/goreleaser-pro/pkg/config"
+	"github.com/goreleaser/goreleaser-pro/v2/pkg/config"
 )
 
 const ArmArch = "arm"
@@ -51,6 +51,7 @@ func Generate(dist string) config.Project {
 		Signs:           Sign(),
 		DockerSigns:     DockerSigns(),
 		SBOMs:           SBOM(),
+		Version:         2,
 	}
 }
 
@@ -112,7 +113,7 @@ func WinPackages(dist string) []config.MSI {
 // https://goreleaser.com/customization/msi/
 func WinPackage(dist string) config.MSI {
 	return config.MSI{
-		ID:      dist,
+		ID:   dist,
 		Name: fmt.Sprintf("%s_{{ .Version }}_{{ .Os }}_{{ .MsiArch }}", dist),
 		WXS:  "windows-installer.wxs",
 		Files: []string{

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -1,5 +1,6 @@
 partial:
   by: target
+version: 2
 project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -1,5 +1,6 @@
 partial:
   by: target
+version: 2
 project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-releases
 go 1.22
 
 require (
-	github.com/goreleaser/goreleaser-pro v1.25.1-pro
+	github.com/goreleaser/goreleaser-pro/v2 v2.1.0-pro
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/goreleaser/goreleaser-pro v1.25.1-pro h1:NOoSx96oAK0zNA1+hiL0p6pY1DWL101kwPmpmkiExXk=
-github.com/goreleaser/goreleaser-pro v1.25.1-pro/go.mod h1:7q9HURJC4ZYBT9VyX3XlqjK0kwe5QbG/VIUAJSP3CKc=
+github.com/goreleaser/goreleaser-pro/v2 v2.1.0-pro h1:9SYFXdnxoLB/8RRazytwFjKg/+394hjVplm7YLcXpQ8=
+github.com/goreleaser/goreleaser-pro/v2 v2.1.0-pro/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=


### PR DESCRIPTION
This PR bumps goreleaser in the `go.mod` file to v2 since that is the version that's used in all pipelines anyways (see e.g. [this goreleaser usage](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/.github/workflows/base-ci-goreleaser.yaml#L70)).