### PR TITLE
fix linux package dependencies

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -146,6 +146,11 @@ func Package(dist string) config.NFPM {
 					"/bin/sh",
 				},
 			},
+			"deb": {
+				Dependencies: []string{
+					"bash",
+				},
+			},
 		},
 
 		NFPMOverridables: config.NFPMOverridables{

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -140,6 +140,13 @@ func Package(dist string) config.NFPM {
 		License:     "Apache 2.0",
 		Description: fmt.Sprintf("OpenTelemetry Collector - %s", dist),
 		Maintainer:  "The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>",
+		Overrides: map[string]config.NFPMOverridables{
+			"rpm": {
+				Dependencies: []string{
+					"/bin/sh",
+				},
+			},
+		},
 
 		NFPMOverridables: config.NFPMOverridables{
 			PackageName: dist,
@@ -164,7 +171,6 @@ func Package(dist string) config.NFPM {
 					Type:        "config|noreplace",
 				},
 			},
-			Dependencies: []string{"/bin/sh"},
 		},
 	}
 }

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -146,11 +146,6 @@ func Package(dist string) config.NFPM {
 					"/bin/sh",
 				},
 			},
-			"deb": {
-				Dependencies: []string{
-					"bash",
-				},
-			},
 		},
 
 		NFPMOverridables: config.NFPMOverridables{

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -69,6 +69,9 @@ nfpms:
       postinstall: postinstall.sh
       preremove: preremove.sh
     overrides:
+      deb:
+        dependencies:
+          - bash
       rpm:
         dependencies:
           - /bin/sh

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -55,8 +55,6 @@ archives:
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
   - package_name: otelcol-contrib
-    dependencies:
-      - /bin/sh
     contents:
       - src: otelcol-contrib.service
         dst: /lib/systemd/system/otelcol-contrib.service
@@ -70,6 +68,10 @@ nfpms:
       preinstall: preinstall.sh
       postinstall: postinstall.sh
       preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
     id: otelcol-contrib
     builds:
       - otelcol-contrib

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -69,9 +69,6 @@ nfpms:
       postinstall: postinstall.sh
       preremove: preremove.sh
     overrides:
-      deb:
-        dependencies:
-          - bash
       rpm:
         dependencies:
           - /bin/sh

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -69,6 +69,9 @@ nfpms:
       postinstall: postinstall.sh
       preremove: preremove.sh
     overrides:
+      deb:
+        dependencies:
+          - bash
       rpm:
         dependencies:
           - /bin/sh

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -69,9 +69,6 @@ nfpms:
       postinstall: postinstall.sh
       preremove: preremove.sh
     overrides:
-      deb:
-        dependencies:
-          - bash
       rpm:
         dependencies:
           - /bin/sh

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -55,8 +55,6 @@ archives:
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
   - package_name: otelcol
-    dependencies:
-      - /bin/sh
     contents:
       - src: otelcol.service
         dst: /lib/systemd/system/otelcol.service
@@ -70,6 +68,10 @@ nfpms:
       preinstall: preinstall.sh
       postinstall: postinstall.sh
       preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
     id: otelcol
     builds:
       - otelcol


### PR DESCRIPTION
Follow up PR to #244 because the last PR added `/bin/sh` to both the .deb and the .rpm package. But this only works for the RPM package for some reason.
(it also was only requested for the RPM package though)