### PR TITLE
Jackgopack4/go1.23 ci fix

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           check-latest: true
 
       - name: Generate the sources

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           check-latest: true
 
       - name: Setup wixl # Required to build MSI packages for Windows
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           check-latest: true
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ~1.21.5
+          go-version: ~1.23
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:

--- a/.github/workflows/builder-testbuild.yaml
+++ b/.github/workflows/builder-testbuild.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ~1.21.5
+          go-version: ~1.23
       - name: Check GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           check-latest: true
 
       - name: Verify

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -52,6 +52,9 @@ func Generate(dist string) config.Project {
 		DockerSigns:     DockerSigns(),
 		SBOMs:           SBOM(),
 		Version:         2,
+		Monorepo:				 config.Monorepo{
+			TagPrefix: "v",
+		},
 	}
 }
 

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -261,3 +261,5 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
+monorepo:
+  tag_prefix: v

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -261,3 +261,5 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
+monorepo:
+  tag_prefix: v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-releases
 
-go 1.22
+go 1.23
 
 require (
 	github.com/goreleaser/goreleaser-pro/v2 v2.1.0-pro


### PR DESCRIPTION
fixes failing ci tests now that repo has two tags associated with it.

Adds "Monorepo" tag in GoReleaser via the template go file.

Includes changes from https://github.com/open-telemetry/opentelemetry-collector-releases/pull/638