### PR TITLE
[chore] remove package test workaround

### DIFF
--- a/scripts/package-tests/package-tests.sh
+++ b/scripts/package-tests/package-tests.sh
@@ -44,19 +44,6 @@ podman build -t "$image_name" -f "$SCRIPT_DIR/Dockerfile.test.$pkg_type" "$SCRIP
 podman rm -fv "$container_name" >/dev/null 2>&1 || true
 
 # test install
-CRUN_VER='1.14.4'
-mkdir -p "${HOME}/.local/bin"
-curl -L "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64" -o "${HOME}/.local/bin/crun"
-chmod +x "${HOME}/.local/bin/crun"
-mkdir -p "${HOME}/.config/containers"
-cat << EOF > "${HOME}/.config/containers/containers.conf"
-[engine.runtimes]
-crun = [
-  "${HOME}/.local/bin/crun",
-  "/usr/bin/crun"
-]
-EOF
-
 podman run --name "$container_name" -d "$image_name"
 
 # ensure that the system is up and running by checking if systemctl is running


### PR DESCRIPTION
This PR removes a workaround first introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31527 which is no longer needed.

Fixes #621