### PR TITLE
Pin CI goreleaser version to v2.2.0

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v2.2.0
           workdir: distributions/${{ inputs.distribution }}
           args: --snapshot --clean --skip=sign,sbom --timeout 2h --split
         env:


### PR DESCRIPTION
Version 2.3 of goreleaser changed some of the output directory names, making the `Upload linux service packages` task fail silently, causing the `Package tests` tasks to fail at retrieving the package artifacts under test.

This PR pins the version of goreleaser used in the CI to the previous one, v2.2.0, to resolve the issue.

We could also pin to v2.3 and update the expected directory name, but it seems that the name of output directories are not considered stable by goreleaser, so I think a better long-term solution is needed.