### PR TITLE
Pin goreleaser to v2.2.0 in remaining CI workflows

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -83,7 +83,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v2.2.0
           workdir: distributions/${{ inputs.distribution }}
           args: release --clean --split --timeout 2h --release-header-tmpl=../../.github/release-template.md
         env:
@@ -154,7 +154,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v2.2.0
           workdir: distributions/${{ inputs.distribution }}
           args: continue --merge --timeout 2h
         env:

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v2.2.0
           args: release --clean -f cmd/builder/.goreleaser.yml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/builder-testbuild.yaml
+++ b/.github/workflows/builder-testbuild.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v2.2.0
           args: check --verbose -f cmd/builder/.goreleaser.yml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
@@ -53,7 +53,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v2.2.0
           args: --snapshot --clean -f cmd/builder/.goreleaser.yml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
The release CI is currently [partly broken](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/11012954579/job/30580454848), for reasons related to my previous PR #667. It [can be fixed](https://github.com/jade-guiton-dd/opentelemetry-collector-releases/actions/runs/11013398401/job/30582310683) temporarily by pinning goreleaser to the previous version, v2.2.0.