### PR TITLE
[chore] refactor(contrib): remove unused replace directive for `go-connections` package

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -225,8 +225,6 @@ providers:
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
-  # See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12322#issuecomment-1185029670
-  - github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 => github.com/docker/go-connections v0.4.0
   # see https://github.com/mattn/go-ieproxy/issues/45
   - github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
   # see https://github.com/openshift/api/pull/1515


### PR DESCRIPTION
The package `github.com/docker/go-connections` only exists in contrib's generated `go.mod` file in version `v0.5.0`, and does not exist in the replaced version `v0.4.1`. The distro also builds and runs fine without the replace directive.

I believe the [reason](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12322#issuecomment-1185029670) for the replace directive to had been added is out of date. To be sure, I have run the repro scenario described [here](https://github.com/docker/go-connections/issues/99#issuecomment-1782151119) and the behavior with go-connections v0.5.0 was correct - the Docker client tried to connect to the TCP port.