### PR TITLE
downgrade to go1.22 until there's a fix for timer

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23'
+          go-version: "1.22"
           check-latest: true
 
       - name: Generate the sources

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23'
+          go-version: "1.22"
           check-latest: true
 
       - name: Setup wixl # Required to build MSI packages for Windows
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23'
+          go-version: "1.22"
           check-latest: true
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ~1.23
+          go-version: ~1.22
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:

--- a/.github/workflows/builder-testbuild.yaml
+++ b/.github/workflows/builder-testbuild.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ~1.23
+          go-version: ~1.22
       - name: Check GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23'
+          go-version: "1.22"
           check-latest: true
 
       - name: Verify

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-releases
 
-go 1.23
+go 1.22
 
 require (
 	github.com/goreleaser/goreleaser-pro/v2 v2.2.0-pro


### PR DESCRIPTION
Proposing to downgrade the version of go used to produce the binary to give implementing a solution for https://github.com/open-telemetry/opentelemetry-collector/issues/11332 more time without impacting end users of the binary.