### PR TITLE
fix: add missing http ports to dockerfile expose statements

### DIFF
--- a/distributions/otelcol-contrib/Dockerfile
+++ b/distributions/otelcol-contrib/Dockerfile
@@ -11,4 +11,4 @@ COPY --chmod=755 otelcol-contrib /otelcol-contrib
 COPY config.yaml /etc/otelcol-contrib/config.yaml
 ENTRYPOINT ["/otelcol-contrib"]
 CMD ["--config", "/etc/otelcol-contrib/config.yaml"]
-EXPOSE 4317 55678 55679
+EXPOSE 4317 4318 55678 55679

--- a/distributions/otelcol/Dockerfile
+++ b/distributions/otelcol/Dockerfile
@@ -11,4 +11,4 @@ COPY --chmod=755 otelcol /otelcol
 COPY config.yaml /etc/otelcol/config.yaml
 ENTRYPOINT ["/otelcol"]
 CMD ["--config", "/etc/otelcol/config.yaml"]
-EXPOSE 4317 55678 55679
+EXPOSE 4317 4318 55678 55679


### PR DESCRIPTION
This PR adds missing HTTP ports to the Dockerfile `EXPOSE` statements for otelcol and otelcol-contrib.

Fixes #692 