### PR TITLE
[chore] build compatible distributions as PIE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ goreleaser:
 		fi \
 	}
 
-REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
+REMOTE?=git@github.com:jackgopack4/opentelemetry-collector-releases.git
 .PHONY: push-tags
 push-tags:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
@@ -74,7 +74,7 @@ push-tags:
 	@git push ${REMOTE} ${TAG}
 
 # Used for debug only
-REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
+REMOTE?=git@github.com:jackgopack4/opentelemetry-collector-releases.git
 .PHONY: delete-tags
 delete-tags:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
@@ -90,6 +90,6 @@ delete-tags:
 	@git push ${REMOTE} :refs/tags/cmd/builder/${TAG}
 
 # Used for debug only
-REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
+REMOTE?=git@github.com:jackgopack4/opentelemetry-collector-releases.git
 .PHONY: repeat-tags
 repeat-tags: delete-tags push-tags

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ goreleaser:
 		fi \
 	}
 
-REMOTE?=git@github.com:jackgopack4/opentelemetry-collector-releases.git
+REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
 .PHONY: push-tags
 push-tags:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
@@ -74,7 +74,7 @@ push-tags:
 	@git push ${REMOTE} ${TAG}
 
 # Used for debug only
-REMOTE?=git@github.com:jackgopack4/opentelemetry-collector-releases.git
+REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
 .PHONY: delete-tags
 delete-tags:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
@@ -90,6 +90,6 @@ delete-tags:
 	@git push ${REMOTE} :refs/tags/cmd/builder/${TAG}
 
 # Used for debug only
-REMOTE?=git@github.com:jackgopack4/opentelemetry-collector-releases.git
+REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
 .PHONY: repeat-tags
 repeat-tags: delete-tags push-tags

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -30,10 +30,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-builder:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
+      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-builder:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -47,10 +47,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-builder:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
+      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-builder:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -64,10 +64,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-builder:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-builder:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -79,32 +79,32 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-builder:{{ .Version }}
+  - name_template: johnpeterson785/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-  - name_template: otel/opentelemetry-collector-builder:latest
+      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+  - name_template: johnpeterson785/opentelemetry-collector-builder:latest
     image_templates:
-      - otel/opentelemetry-collector-builder:latest-amd64
-      - otel/opentelemetry-collector-builder:latest-arm64
-      - otel/opentelemetry-collector-builder:latest-ppc64le
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}
+      - johnpeterson785/opentelemetry-collector-builder:latest-amd64
+      - johnpeterson785/opentelemetry-collector-builder:latest-arm64
+      - johnpeterson785/opentelemetry-collector-builder:latest-ppc64le
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
 release:
   github:
-    owner: open-telemetry
+    owner: jackgopack4
     name: opentelemetry-collector-releases
   header: |
-    ### Images and binaries for collector distributions here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
+    ### Images and binaries for collector distributions here: https://github.com/jackgopack4/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
 archives:
   - format: binary
 checksum:

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -8,6 +8,7 @@ version: 2
 builds:
   - flags:
       - -trimpath
+      - -buildmode=pie
     ldflags:
       - -s -w -X go.opentelemetry.io/collector/cmd/builder/internal.version={{ .Version }}
     env:
@@ -136,4 +137,3 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
-    

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -30,10 +30,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-builder:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
+      - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-builder:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -47,10 +47,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-builder:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
+      - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-builder:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -64,10 +64,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-builder:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
+      - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-builder:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -79,32 +79,32 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector-builder:{{ .Version }}
+  - name_template: otel/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-  - name_template: johnpeterson785/opentelemetry-collector-builder:latest
+      - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+  - name_template: otel/opentelemetry-collector-builder:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector-builder:latest-amd64
-      - johnpeterson785/opentelemetry-collector-builder:latest-arm64
-      - johnpeterson785/opentelemetry-collector-builder:latest-ppc64le
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}
+      - otel/opentelemetry-collector-builder:latest-amd64
+      - otel/opentelemetry-collector-builder:latest-arm64
+      - otel/opentelemetry-collector-builder:latest-ppc64le
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
 release:
   github:
-    owner: jackgopack4
+    owner: open-telemetry
     name: opentelemetry-collector-releases
   header: |
-    ### Images and binaries for collector distributions here: https://github.com/jackgopack4/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
+    ### Images and binaries for collector distributions here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
 archives:
   - format: binary
 checksum:

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -209,13 +209,20 @@ func Packages(dist string) (r []config.NFPM) {
 		return []config.NFPM{}
 	}
 	return []config.NFPM{
-		Package(dist),
+		Package(dist, true),
+		Package(dist, false),
 	}
 }
 
 // Package configures goreleaser to build a system package.
 // https://goreleaser.com/customization/nfpm/
-func Package(dist string) config.NFPM {
+func Package(dist string, pie bool) config.NFPM {
+	id := dist
+	build := dist
+	if pie {
+		id = id + "-pie"
+		build = build + "-pie"
+	}
 	nfpmContents := config.NFPMContents{
 		{
 			Source:      fmt.Sprintf("%s.service", dist),
@@ -235,8 +242,8 @@ func Package(dist string) config.NFPM {
 		})
 	}
 	return config.NFPM{
-		ID:      dist,
-		Builds:  []string{dist},
+		ID:      id,
+		Builds:  []string{build},
 		Formats: []string{"deb", "rpm"},
 
 		License:     "Apache 2.0",
@@ -251,7 +258,7 @@ func Package(dist string) config.NFPM {
 		},
 
 		NFPMOverridables: config.NFPMOverridables{
-			PackageName: dist,
+			PackageName: id,
 			Scripts: config.NFPMScripts{
 				PreInstall:  "preinstall.sh",
 				PostInstall: "postinstall.sh",

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -258,7 +258,7 @@ func Package(dist string, pie bool) config.NFPM {
 		},
 
 		NFPMOverridables: config.NFPMOverridables{
-			PackageName: id,
+			PackageName: dist,
 			Scripts: config.NFPMScripts{
 				PreInstall:  "preinstall.sh",
 				PostInstall: "postinstall.sh",

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -48,7 +48,28 @@ var (
 	K8sDockerSkipArchs = map[string]bool{"arm": true, "386": true}
 	K8sGoos            = []string{"linux"}
 	K8sArchs           = []string{"amd64", "arm64", "ppc64le", "s390x"}
+	AlwaysIgnored      = map[config.IgnoredBuild]bool{
+		{Goos: "darwin", Goarch: "386"}:    true,
+		{Goos: "darwin", Goarch: "arm"}:    true,
+		{Goos: "darwin", Goarch: "s390x"}:  true,
+		{Goos: "windows", Goarch: "arm"}:   true,
+		{Goos: "windows", Goarch: "arm64"}: true,
+		{Goos: "windows", Goarch: "s390x"}: true,
+	}
 )
+
+// Copied from go/src/internal/platform/supported.go, see:
+// https://cs.opensource.google/go/go/+/d7fcb5cf80953f1d63246f1ae9defa60c5ce2d76:src/internal/platform/supported.go;l=222
+func InternalLinkPIESupported(goos, goarch string) bool {
+	switch goos + "/" + goarch {
+	case "android/arm64",
+		"darwin/amd64", "darwin/arm64",
+		"linux/amd64", "linux/arm64", "linux/ppc64le",
+		"windows/386", "windows/amd64", "windows/arm", "windows/arm64":
+		return true
+	}
+	return false
+}
 
 func Generate(dist string) config.Project {
 	return config.Project{
@@ -75,35 +96,51 @@ func Generate(dist string) config.Project {
 
 func Builds(dist string) []config.Build {
 	return []config.Build{
-		Build(dist),
+		Build(dist, true),
+		Build(dist, false),
 	}
+}
+
+func generateIgnored(goos, archs []string, pie bool) []config.IgnoredBuild {
+	ignored := make([]config.IgnoredBuild, 0)
+	var build config.IgnoredBuild
+	for _, goos := range goos {
+		for _, arch := range archs {
+			build = config.IgnoredBuild{
+				Goos:   goos,
+				Goarch: arch,
+			}
+			if _, ok := AlwaysIgnored[build]; ok || !pie && InternalLinkPIESupported(goos, arch) || pie && !InternalLinkPIESupported(goos, arch) {
+				ignored = append(ignored, build)
+			}
+		}
+	}
+	return ignored
 }
 
 // Build configures a goreleaser build.
 // https://goreleaser.com/customization/build/
-func Build(dist string) config.Build {
+func Build(dist string, pie bool) config.Build {
 	var goos []string
 	var archs []string
 	var ignore []config.IgnoredBuild
 	var armVersions []string
+	id := dist
+	ldflags := []string{"-s", "-w"}
+	if pie {
+		ldflags = append(ldflags, "-buildmode=pie")
+		id = id + "-pie"
+	}
 	if dist == K8sDistro {
 		goos = K8sGoos
 		archs = K8sArchs
-		ignore = make([]config.IgnoredBuild, 0)
 		armVersions = make([]string, 0)
 	} else {
 		goos = []string{"darwin", "linux", "windows"}
 		archs = Architectures
-		ignore = []config.IgnoredBuild{
-			{Goos: "darwin", Goarch: "386"},
-			{Goos: "darwin", Goarch: "arm"},
-			{Goos: "darwin", Goarch: "s390x"},
-			{Goos: "windows", Goarch: "arm"},
-			{Goos: "windows", Goarch: "arm64"},
-			{Goos: "windows", Goarch: "s390x"},
-		}
 		armVersions = ArmVersions
 	}
+	ignore = generateIgnored(goos, archs, pie)
 	return config.Build{
 		ID:     dist,
 		Dir:    "_build",
@@ -111,7 +148,7 @@ func Build(dist string) config.Build {
 		BuildDetails: config.BuildDetails{
 			Env:     []string{"CGO_ENABLED=0"},
 			Flags:   []string{"-trimpath"},
-			Ldflags: []string{"-s", "-w"},
+			Ldflags: ldflags,
 		},
 		Goos:   goos,
 		Goarch: archs,
@@ -122,17 +159,24 @@ func Build(dist string) config.Build {
 
 func Archives(dist string) (r []config.Archive) {
 	return []config.Archive{
-		Archive(dist),
+		Archive(dist, true),
+		Archive(dist, false),
 	}
 }
 
 // Archive configures a goreleaser archive (tarball).
 // https://goreleaser.com/customization/archive/
-func Archive(dist string) config.Archive {
+func Archive(dist string, pie bool) config.Archive {
+	id := dist
+	build := dist
+	if pie {
+		id = id + "-pie"
+		build = build + "-pie"
+	}
 	return config.Archive{
-		ID:           dist,
+		ID:           id,
 		NameTemplate: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}",
-		Builds:       []string{dist},
+		Builds:       []string{build},
 	}
 }
 
@@ -165,13 +209,20 @@ func Packages(dist string) (r []config.NFPM) {
 		return []config.NFPM{}
 	}
 	return []config.NFPM{
-		Package(dist),
+		Package(dist, true),
+		Package(dist, false),
 	}
 }
 
 // Package configures goreleaser to build a system package.
 // https://goreleaser.com/customization/nfpm/
-func Package(dist string) config.NFPM {
+func Package(dist string, pie bool) config.NFPM {
+	id := dist
+	build := dist
+	if pie {
+		id = id + "-pie"
+		build = build + "-pie"
+	}
 	nfpmContents := config.NFPMContents{
 		{
 			Source:      fmt.Sprintf("%s.service", dist),
@@ -191,8 +242,8 @@ func Package(dist string) config.NFPM {
 		})
 	}
 	return config.NFPM{
-		ID:      dist,
-		Builds:  []string{dist},
+		ID:      id,
+		Builds:  []string{build},
 		Formats: []string{"deb", "rpm"},
 
 		License:     "Apache 2.0",

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -209,20 +209,13 @@ func Packages(dist string) (r []config.NFPM) {
 		return []config.NFPM{}
 	}
 	return []config.NFPM{
-		Package(dist, true),
-		Package(dist, false),
+		Package(dist),
 	}
 }
 
 // Package configures goreleaser to build a system package.
 // https://goreleaser.com/customization/nfpm/
-func Package(dist string, pie bool) config.NFPM {
-	id := dist
-	build := dist
-	if pie {
-		id = id + "-pie"
-		build = build + "-pie"
-	}
+func Package(dist string) config.NFPM {
 	nfpmContents := config.NFPMContents{
 		{
 			Source:      fmt.Sprintf("%s.service", dist),
@@ -242,8 +235,8 @@ func Package(dist string, pie bool) config.NFPM {
 		})
 	}
 	return config.NFPM{
-		ID:      id,
-		Builds:  []string{build},
+		ID:      dist,
+		Builds:  []string{dist},
 		Formats: []string{"deb", "rpm"},
 
 		License:     "Apache 2.0",
@@ -258,7 +251,7 @@ func Package(dist string, pie bool) config.NFPM {
 		},
 
 		NFPMOverridables: config.NFPMOverridables{
-			PackageName: id,
+			PackageName: dist,
 			Scripts: config.NFPMScripts{
 				PreInstall:  "preinstall.sh",
 				PostInstall: "postinstall.sh",

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -209,20 +209,14 @@ func Packages(dist string) (r []config.NFPM) {
 		return []config.NFPM{}
 	}
 	return []config.NFPM{
-		Package(dist, true),
-		Package(dist, false),
+		Package(dist),
 	}
 }
 
 // Package configures goreleaser to build a system package.
 // https://goreleaser.com/customization/nfpm/
-func Package(dist string, pie bool) config.NFPM {
-	id := dist
-	build := dist
-	if pie {
-		id = id + "-pie"
-		build = build + "-pie"
-	}
+func Package(dist string) config.NFPM {
+	buildPie := dist + "-pie"
 	nfpmContents := config.NFPMContents{
 		{
 			Source:      fmt.Sprintf("%s.service", dist),
@@ -242,8 +236,8 @@ func Package(dist string, pie bool) config.NFPM {
 		})
 	}
 	return config.NFPM{
-		ID:      id,
-		Builds:  []string{build},
+		ID:      dist,
+		Builds:  []string{dist, buildPie},
 		Formats: []string{"deb", "rpm"},
 
 		License:     "Apache 2.0",

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -258,7 +258,7 @@ func Package(dist string, pie bool) config.NFPM {
 		},
 
 		NFPMOverridables: config.NFPMOverridables{
-			PackageName: dist,
+			PackageName: id,
 			Scripts: config.NFPMScripts{
 				PreInstall:  "preinstall.sh",
 				PostInstall: "postinstall.sh",

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -33,8 +33,8 @@ const (
 	ContribDistro    = "otelcol-contrib"
 	K8sDistro        = "otelcol-k8s"
 	OTLPDistro       = "otelcol-otlp"
-	DockerHub        = "johnpeterson785"
-	GHCR             = "ghcr.io/jackgopack4/opentelemetry-collector-releases"
+	DockerHub        = "otel"
+	GHCR             = "ghcr.io/open-telemetry/opentelemetry-collector-releases"
 	BinaryNamePrefix = "otelcol"
 	ImageNamePrefix  = "opentelemetry-collector"
 )

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -142,7 +142,7 @@ func Build(dist string, pie bool) config.Build {
 	}
 	ignore = generateIgnored(goos, archs, pie)
 	return config.Build{
-		ID:     dist,
+		ID:     id,
 		Dir:    "_build",
 		Binary: dist,
 		BuildDetails: config.BuildDetails{

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -33,8 +33,8 @@ const (
 	ContribDistro    = "otelcol-contrib"
 	K8sDistro        = "otelcol-k8s"
 	OTLPDistro       = "otelcol-otlp"
-	DockerHub        = "otel"
-	GHCR             = "ghcr.io/open-telemetry/opentelemetry-collector-releases"
+	DockerHub        = "johnpeterson785"
+	GHCR             = "ghcr.io/jackgopack4/opentelemetry-collector-releases"
 	BinaryNamePrefix = "otelcol"
 	ImageNamePrefix  = "opentelemetry-collector"
 )

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -180,10 +180,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
-      - otel/opentelemetry-collector-contrib:latest-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-386
+      - johnpeterson785/opentelemetry-collector-contrib:latest-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -200,10 +200,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-contrib:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-contrib:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -221,10 +221,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-contrib:latest-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - johnpeterson785/opentelemetry-collector-contrib:latest-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -241,10 +241,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-contrib:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-contrib:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -261,10 +261,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-contrib:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-contrib:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -281,10 +281,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - otel/opentelemetry-collector-contrib:latest-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-s390x
+      - johnpeterson785/opentelemetry-collector-contrib:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -298,38 +298,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
+  - name_template: johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector-contrib:latest
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-386
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-s390x
+  - name_template: johnpeterson785/opentelemetry-collector-contrib:latest
     image_templates:
-      - otel/opentelemetry-collector-contrib:latest-386
-      - otel/opentelemetry-collector-contrib:latest-amd64
-      - otel/opentelemetry-collector-contrib:latest-armv7
-      - otel/opentelemetry-collector-contrib:latest-arm64
-      - otel/opentelemetry-collector-contrib:latest-ppc64le
-      - otel/opentelemetry-collector-contrib:latest-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
+      - johnpeterson785/opentelemetry-collector-contrib:latest-386
+      - johnpeterson785/opentelemetry-collector-contrib:latest-amd64
+      - johnpeterson785/opentelemetry-collector-contrib:latest-armv7
+      - johnpeterson785/opentelemetry-collector-contrib:latest-arm64
+      - johnpeterson785/opentelemetry-collector-contrib:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-contrib:latest-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -119,7 +119,7 @@ archives:
       - otelcol-contrib
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-contrib
+  - package_name: otelcol-contrib-pie
     contents:
       - src: otelcol-contrib.service
         dst: /lib/systemd/system/otelcol-contrib.service

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -119,33 +119,6 @@ archives:
       - otelcol-contrib
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-contrib-pie
-    contents:
-      - src: otelcol-contrib.service
-        dst: /lib/systemd/system/otelcol-contrib.service
-      - src: otelcol-contrib.conf
-        dst: /etc/otelcol-contrib/otelcol-contrib.conf
-        type: config|noreplace
-      - src: config.yaml
-        dst: /etc/otelcol-contrib/config.yaml
-        type: config|noreplace
-    scripts:
-      preinstall: preinstall.sh
-      postinstall: postinstall.sh
-      preremove: preremove.sh
-    overrides:
-      rpm:
-        dependencies:
-          - /bin/sh
-    id: otelcol-contrib-pie
-    builds:
-      - otelcol-contrib-pie
-    formats:
-      - deb
-      - rpm
-    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
-    description: OpenTelemetry Collector - otelcol-contrib
-    license: Apache 2.0
   - package_name: otelcol-contrib
     contents:
       - src: otelcol-contrib.service

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -119,6 +119,33 @@ archives:
       - otelcol-contrib
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
+  - package_name: otelcol-contrib-pie
+    contents:
+      - src: otelcol-contrib.service
+        dst: /lib/systemd/system/otelcol-contrib.service
+      - src: otelcol-contrib.conf
+        dst: /etc/otelcol-contrib/otelcol-contrib.conf
+        type: config|noreplace
+      - src: config.yaml
+        dst: /etc/otelcol-contrib/config.yaml
+        type: config|noreplace
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: otelcol-contrib-pie
+    builds:
+      - otelcol-contrib-pie
+    formats:
+      - deb
+      - rpm
+    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
+    description: OpenTelemetry Collector - otelcol-contrib
+    license: Apache 2.0
   - package_name: otelcol-contrib
     contents:
       - src: otelcol-contrib.service

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -137,36 +137,10 @@ nfpms:
       rpm:
         dependencies:
           - /bin/sh
-    id: otelcol-contrib-pie
-    builds:
-      - otelcol-contrib-pie
-    formats:
-      - deb
-      - rpm
-    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
-    description: OpenTelemetry Collector - otelcol-contrib
-    license: Apache 2.0
-  - package_name: otelcol-contrib
-    contents:
-      - src: otelcol-contrib.service
-        dst: /lib/systemd/system/otelcol-contrib.service
-      - src: otelcol-contrib.conf
-        dst: /etc/otelcol-contrib/otelcol-contrib.conf
-        type: config|noreplace
-      - src: config.yaml
-        dst: /etc/otelcol-contrib/config.yaml
-        type: config|noreplace
-    scripts:
-      preinstall: preinstall.sh
-      postinstall: postinstall.sh
-      preremove: preremove.sh
-    overrides:
-      rpm:
-        dependencies:
-          - /bin/sh
     id: otelcol-contrib
     builds:
       - otelcol-contrib
+      - otelcol-contrib-pie
     formats:
       - deb
       - rpm

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -32,7 +32,68 @@ builds:
       - goos: darwin
         goarch: arm
       - goos: darwin
+        goarch: ppc64le
+      - goos: darwin
         goarch: s390x
+      - goos: linux
+        goarch: "386"
+      - goos: linux
+        goarch: arm
+      - goos: linux
+        goarch: s390x
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: ppc64le
+      - goos: windows
+        goarch: s390x
+    dir: _build
+    binary: otelcol-contrib
+    ldflags:
+      - -s
+      - -w
+      - -buildmode=pie
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+  - id: otelcol-contrib
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm
+      - arm64
+      - ppc64le
+      - s390x
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: amd64
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: arm64
+      - goos: darwin
+        goarch: s390x
+      - goos: linux
+        goarch: amd64
+      - goos: linux
+        goarch: arm64
+      - goos: linux
+        goarch: ppc64le
+      - goos: windows
+        goarch: "386"
+      - goos: windows
+        goarch: amd64
       - goos: windows
         goarch: arm
       - goos: windows
@@ -49,11 +110,42 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
+  - id: otelcol-contrib-pie
+    builds:
+      - otelcol-contrib-pie
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol-contrib
     builds:
       - otelcol-contrib
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
+  - package_name: otelcol-contrib
+    contents:
+      - src: otelcol-contrib.service
+        dst: /lib/systemd/system/otelcol-contrib.service
+      - src: otelcol-contrib.conf
+        dst: /etc/otelcol-contrib/otelcol-contrib.conf
+        type: config|noreplace
+      - src: config.yaml
+        dst: /etc/otelcol-contrib/config.yaml
+        type: config|noreplace
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: otelcol-contrib-pie
+    builds:
+      - otelcol-contrib-pie
+    formats:
+      - deb
+      - rpm
+    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
+    description: OpenTelemetry Collector - otelcol-contrib
+    license: Apache 2.0
   - package_name: otelcol-contrib
     contents:
       - src: otelcol-contrib.service

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -119,7 +119,7 @@ archives:
       - otelcol-contrib
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-contrib-pie
+  - package_name: otelcol-contrib
     contents:
       - src: otelcol-contrib.service
         dst: /lib/systemd/system/otelcol-contrib.service

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -154,10 +154,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-contrib:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
+      - otel/opentelemetry-collector-contrib:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -174,10 +174,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-contrib:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -195,10 +195,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-contrib:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-contrib:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -215,10 +215,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-contrib:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -235,10 +235,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-contrib:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-contrib:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -255,10 +255,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector-contrib:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
+      - otel/opentelemetry-collector-contrib:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -272,38 +272,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}
+  - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector-contrib:latest
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector-contrib:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:latest-386
-      - johnpeterson785/opentelemetry-collector-contrib:latest-amd64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-armv7
-      - johnpeterson785/opentelemetry-collector-contrib:latest-arm64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector-contrib:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
+      - otel/opentelemetry-collector-contrib:latest-386
+      - otel/opentelemetry-collector-contrib:latest-amd64
+      - otel/opentelemetry-collector-contrib:latest-armv7
+      - otel/opentelemetry-collector-contrib:latest-arm64
+      - otel/opentelemetry-collector-contrib:latest-ppc64le
+      - otel/opentelemetry-collector-contrib:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -12,7 +12,7 @@ msi:
       - opentelemetry.ico
       - config.yaml
 builds:
-  - id: otelcol-contrib
+  - id: otelcol-contrib-pie
     goos:
       - darwin
       - linux

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -180,10 +180,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-contrib:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
+      - otel/opentelemetry-collector-contrib:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -200,10 +200,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-contrib:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -221,10 +221,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-contrib:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-contrib:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -241,10 +241,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-contrib:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -261,10 +261,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-contrib:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-contrib:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -281,10 +281,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector-contrib:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
+      - otel/opentelemetry-collector-contrib:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -298,38 +298,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}
+  - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector-contrib:latest
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector-contrib:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector-contrib:latest-386
-      - johnpeterson785/opentelemetry-collector-contrib:latest-amd64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-armv7
-      - johnpeterson785/opentelemetry-collector-contrib:latest-arm64
-      - johnpeterson785/opentelemetry-collector-contrib:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector-contrib:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
+      - otel/opentelemetry-collector-contrib:latest-386
+      - otel/opentelemetry-collector-contrib:latest-amd64
+      - otel/opentelemetry-collector-contrib:latest-armv7
+      - otel/opentelemetry-collector-contrib:latest-arm64
+      - otel/opentelemetry-collector-contrib:latest-ppc64le
+      - otel/opentelemetry-collector-contrib:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -66,10 +66,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-k8s:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-k8s:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -84,10 +84,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-k8s:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-k8s:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -102,10 +102,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-k8s:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-k8s:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -120,10 +120,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
-      - otel/opentelemetry-collector-k8s:latest-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-s390x
+      - johnpeterson785/opentelemetry-collector-k8s:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
     build_flag_templates:
       - --pull
       - --platform=linux/s390x
@@ -135,30 +135,30 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-k8s:{{ .Version }}
+  - name_template: johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector-k8s:latest
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-s390x
+  - name_template: johnpeterson785/opentelemetry-collector-k8s:latest
     image_templates:
-      - otel/opentelemetry-collector-k8s:latest-amd64
-      - otel/opentelemetry-collector-k8s:latest-arm64
-      - otel/opentelemetry-collector-k8s:latest-ppc64le
-      - otel/opentelemetry-collector-k8s:latest-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}
+      - johnpeterson785/opentelemetry-collector-k8s:latest-amd64
+      - johnpeterson785/opentelemetry-collector-k8s:latest-arm64
+      - johnpeterson785/opentelemetry-collector-k8s:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-k8s:latest-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -13,6 +13,34 @@ builds:
       - arm64
       - ppc64le
       - s390x
+    ignore:
+      - goos: linux
+        goarch: s390x
+    dir: _build
+    binary: otelcol-k8s
+    ldflags:
+      - -s
+      - -w
+      - -buildmode=pie
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+  - id: otelcol-k8s
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - ppc64le
+      - s390x
+    ignore:
+      - goos: linux
+        goarch: amd64
+      - goos: linux
+        goarch: arm64
+      - goos: linux
+        goarch: ppc64le
     dir: _build
     binary: otelcol-k8s
     ldflags:
@@ -23,6 +51,10 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
+  - id: otelcol-k8s-pie
+    builds:
+      - otelcol-k8s-pie
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol-k8s
     builds:
       - otelcol-k8s

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -66,10 +66,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-k8s:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-k8s:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -84,10 +84,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-k8s:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-k8s:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -102,10 +102,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-k8s:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-k8s:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -120,10 +120,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector-k8s:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
+      - otel/opentelemetry-collector-k8s:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
     build_flag_templates:
       - --pull
       - --platform=linux/s390x
@@ -135,30 +135,30 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}
+  - name_template: otel/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-k8s:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector-k8s:latest
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector-k8s:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector-k8s:latest-amd64
-      - johnpeterson785/opentelemetry-collector-k8s:latest-arm64
-      - johnpeterson785/opentelemetry-collector-k8s:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector-k8s:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}
+      - otel/opentelemetry-collector-k8s:latest-amd64
+      - otel/opentelemetry-collector-k8s:latest-arm64
+      - otel/opentelemetry-collector-k8s:latest-ppc64le
+      - otel/opentelemetry-collector-k8s:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -5,7 +5,7 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
 builds:
-  - id: otelcol-k8s
+  - id: otelcol-k8s-pie
     goos:
       - linux
     goarch:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -173,10 +173,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
-      - otel/opentelemetry-collector-otlp:latest-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-386
+      - johnpeterson785/opentelemetry-collector-otlp:latest-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
     build_flag_templates:
       - --pull
       - --platform=linux/386
@@ -191,10 +191,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-otlp:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-otlp:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -210,10 +210,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-otlp:latest-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - johnpeterson785/opentelemetry-collector-otlp:latest-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
     build_flag_templates:
       - --pull
       - --platform=linux/arm/v7
@@ -228,10 +228,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-otlp:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-otlp:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -246,10 +246,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-otlp:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-otlp:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -264,10 +264,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - otel/opentelemetry-collector-otlp:latest-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-s390x
+      - johnpeterson785/opentelemetry-collector-otlp:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
     build_flag_templates:
       - --pull
       - --platform=linux/s390x
@@ -279,38 +279,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-otlp:{{ .Version }}
+  - name_template: johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector-otlp:latest
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-386
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-s390x
+  - name_template: johnpeterson785/opentelemetry-collector-otlp:latest
     image_templates:
-      - otel/opentelemetry-collector-otlp:latest-386
-      - otel/opentelemetry-collector-otlp:latest-amd64
-      - otel/opentelemetry-collector-otlp:latest-armv7
-      - otel/opentelemetry-collector-otlp:latest-arm64
-      - otel/opentelemetry-collector-otlp:latest-ppc64le
-      - otel/opentelemetry-collector-otlp:latest-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
+      - johnpeterson785/opentelemetry-collector-otlp:latest-386
+      - johnpeterson785/opentelemetry-collector-otlp:latest-amd64
+      - johnpeterson785/opentelemetry-collector-otlp:latest-armv7
+      - johnpeterson785/opentelemetry-collector-otlp:latest-arm64
+      - johnpeterson785/opentelemetry-collector-otlp:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector-otlp:latest-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -118,6 +118,30 @@ archives:
       - otelcol-otlp
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
+  - package_name: otelcol-otlp-pie
+    contents:
+      - src: otelcol-otlp.service
+        dst: /lib/systemd/system/otelcol-otlp.service
+      - src: otelcol-otlp.conf
+        dst: /etc/otelcol-otlp/otelcol-otlp.conf
+        type: config|noreplace
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: otelcol-otlp-pie
+    builds:
+      - otelcol-otlp-pie
+    formats:
+      - deb
+      - rpm
+    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
+    description: OpenTelemetry Collector - otelcol-otlp
+    license: Apache 2.0
   - package_name: otelcol-otlp
     contents:
       - src: otelcol-otlp.service

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -118,7 +118,7 @@ archives:
       - otelcol-otlp
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-otlp
+  - package_name: otelcol-otlp-pie
     contents:
       - src: otelcol-otlp.service
         dst: /lib/systemd/system/otelcol-otlp.service

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -31,7 +31,68 @@ builds:
       - goos: darwin
         goarch: arm
       - goos: darwin
+        goarch: ppc64le
+      - goos: darwin
         goarch: s390x
+      - goos: linux
+        goarch: "386"
+      - goos: linux
+        goarch: arm
+      - goos: linux
+        goarch: s390x
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: ppc64le
+      - goos: windows
+        goarch: s390x
+    dir: _build
+    binary: otelcol-otlp
+    ldflags:
+      - -s
+      - -w
+      - -buildmode=pie
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+  - id: otelcol-otlp
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm
+      - arm64
+      - ppc64le
+      - s390x
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: amd64
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: arm64
+      - goos: darwin
+        goarch: s390x
+      - goos: linux
+        goarch: amd64
+      - goos: linux
+        goarch: arm64
+      - goos: linux
+        goarch: ppc64le
+      - goos: windows
+        goarch: "386"
+      - goos: windows
+        goarch: amd64
       - goos: windows
         goarch: arm
       - goos: windows
@@ -48,11 +109,39 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
+  - id: otelcol-otlp-pie
+    builds:
+      - otelcol-otlp-pie
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol-otlp
     builds:
       - otelcol-otlp
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
+  - package_name: otelcol-otlp
+    contents:
+      - src: otelcol-otlp.service
+        dst: /lib/systemd/system/otelcol-otlp.service
+      - src: otelcol-otlp.conf
+        dst: /etc/otelcol-otlp/otelcol-otlp.conf
+        type: config|noreplace
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: otelcol-otlp-pie
+    builds:
+      - otelcol-otlp-pie
+    formats:
+      - deb
+      - rpm
+    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
+    description: OpenTelemetry Collector - otelcol-otlp
+    license: Apache 2.0
   - package_name: otelcol-otlp
     contents:
       - src: otelcol-otlp.service

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -118,30 +118,6 @@ archives:
       - otelcol-otlp
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-otlp-pie
-    contents:
-      - src: otelcol-otlp.service
-        dst: /lib/systemd/system/otelcol-otlp.service
-      - src: otelcol-otlp.conf
-        dst: /etc/otelcol-otlp/otelcol-otlp.conf
-        type: config|noreplace
-    scripts:
-      preinstall: preinstall.sh
-      postinstall: postinstall.sh
-      preremove: preremove.sh
-    overrides:
-      rpm:
-        dependencies:
-          - /bin/sh
-    id: otelcol-otlp-pie
-    builds:
-      - otelcol-otlp-pie
-    formats:
-      - deb
-      - rpm
-    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
-    description: OpenTelemetry Collector - otelcol-otlp
-    license: Apache 2.0
   - package_name: otelcol-otlp
     contents:
       - src: otelcol-otlp.service

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -173,10 +173,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-otlp:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
+      - otel/opentelemetry-collector-otlp:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
     build_flag_templates:
       - --pull
       - --platform=linux/386
@@ -191,10 +191,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-otlp:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -210,10 +210,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-otlp:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-otlp:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
     build_flag_templates:
       - --pull
       - --platform=linux/arm/v7
@@ -228,10 +228,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-otlp:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -246,10 +246,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-otlp:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-otlp:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -264,10 +264,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector-otlp:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
+      - otel/opentelemetry-collector-otlp:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
     build_flag_templates:
       - --pull
       - --platform=linux/s390x
@@ -279,38 +279,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}
+  - name_template: otel/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector-otlp:latest
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector-otlp:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:latest-386
-      - johnpeterson785/opentelemetry-collector-otlp:latest-amd64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-armv7
-      - johnpeterson785/opentelemetry-collector-otlp:latest-arm64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector-otlp:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
+      - otel/opentelemetry-collector-otlp:latest-386
+      - otel/opentelemetry-collector-otlp:latest-amd64
+      - otel/opentelemetry-collector-otlp:latest-armv7
+      - otel/opentelemetry-collector-otlp:latest-arm64
+      - otel/opentelemetry-collector-otlp:latest-ppc64le
+      - otel/opentelemetry-collector-otlp:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -150,10 +150,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-otlp:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
+      - otel/opentelemetry-collector-otlp:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
     build_flag_templates:
       - --pull
       - --platform=linux/386
@@ -168,10 +168,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-otlp:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -187,10 +187,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-otlp:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-otlp:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
     build_flag_templates:
       - --pull
       - --platform=linux/arm/v7
@@ -205,10 +205,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-otlp:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -223,10 +223,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-otlp:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-otlp:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -241,10 +241,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector-otlp:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
+      - otel/opentelemetry-collector-otlp:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
     build_flag_templates:
       - --pull
       - --platform=linux/s390x
@@ -256,38 +256,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}
+  - name_template: otel/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector-otlp:latest
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector-otlp:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector-otlp:latest-386
-      - johnpeterson785/opentelemetry-collector-otlp:latest-amd64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-armv7
-      - johnpeterson785/opentelemetry-collector-otlp:latest-arm64
-      - johnpeterson785/opentelemetry-collector-otlp:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector-otlp:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
+      - otel/opentelemetry-collector-otlp:latest-386
+      - otel/opentelemetry-collector-otlp:latest-amd64
+      - otel/opentelemetry-collector-otlp:latest-armv7
+      - otel/opentelemetry-collector-otlp:latest-arm64
+      - otel/opentelemetry-collector-otlp:latest-ppc64le
+      - otel/opentelemetry-collector-otlp:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -11,7 +11,7 @@ msi:
     extra_files:
       - opentelemetry.ico
 builds:
-  - id: otelcol-otlp
+  - id: otelcol-otlp-pie
     goos:
       - darwin
       - linux

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -118,7 +118,7 @@ archives:
       - otelcol-otlp
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-otlp-pie
+  - package_name: otelcol-otlp
     contents:
       - src: otelcol-otlp.service
         dst: /lib/systemd/system/otelcol-otlp.service

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -133,33 +133,10 @@ nfpms:
       rpm:
         dependencies:
           - /bin/sh
-    id: otelcol-otlp-pie
-    builds:
-      - otelcol-otlp-pie
-    formats:
-      - deb
-      - rpm
-    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
-    description: OpenTelemetry Collector - otelcol-otlp
-    license: Apache 2.0
-  - package_name: otelcol-otlp
-    contents:
-      - src: otelcol-otlp.service
-        dst: /lib/systemd/system/otelcol-otlp.service
-      - src: otelcol-otlp.conf
-        dst: /etc/otelcol-otlp/otelcol-otlp.conf
-        type: config|noreplace
-    scripts:
-      preinstall: preinstall.sh
-      postinstall: postinstall.sh
-      preremove: preremove.sh
-    overrides:
-      rpm:
-        dependencies:
-          - /bin/sh
     id: otelcol-otlp
     builds:
       - otelcol-otlp
+      - otelcol-otlp-pie
     formats:
       - deb
       - rpm

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -180,10 +180,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-386
-      - otel/opentelemetry-collector:latest-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-386
+      - johnpeterson785/opentelemetry-collector:latest-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-386
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -200,10 +200,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-amd64
-      - otel/opentelemetry-collector:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -221,10 +221,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-armv7
-      - otel/opentelemetry-collector:latest-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-armv7
+      - johnpeterson785/opentelemetry-collector:latest-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -241,10 +241,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-arm64
-      - otel/opentelemetry-collector:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -261,10 +261,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -281,10 +281,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-s390x
-      - otel/opentelemetry-collector:latest-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-s390x
+      - johnpeterson785/opentelemetry-collector:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -298,38 +298,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector:{{ .Version }}
+  - name_template: johnpeterson785/opentelemetry-collector:{{ .Version }}
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-386
-      - otel/opentelemetry-collector:{{ .Version }}-amd64
-      - otel/opentelemetry-collector:{{ .Version }}-armv7
-      - otel/opentelemetry-collector:{{ .Version }}-arm64
-      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector:latest
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-386
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-amd64
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-armv7
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-arm64
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-ppc64le
+      - johnpeterson785/opentelemetry-collector:{{ .Version }}-s390x
+  - name_template: johnpeterson785/opentelemetry-collector:latest
     image_templates:
-      - otel/opentelemetry-collector:latest-386
-      - otel/opentelemetry-collector:latest-amd64
-      - otel/opentelemetry-collector:latest-armv7
-      - otel/opentelemetry-collector:latest-arm64
-      - otel/opentelemetry-collector:latest-ppc64le
-      - otel/opentelemetry-collector:latest-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
+      - johnpeterson785/opentelemetry-collector:latest-386
+      - johnpeterson785/opentelemetry-collector:latest-amd64
+      - johnpeterson785/opentelemetry-collector:latest-armv7
+      - johnpeterson785/opentelemetry-collector:latest-arm64
+      - johnpeterson785/opentelemetry-collector:latest-ppc64le
+      - johnpeterson785/opentelemetry-collector:latest-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest
     image_templates:
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-386
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -119,7 +119,7 @@ archives:
       - otelcol
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-pie
+  - package_name: otelcol
     contents:
       - src: otelcol.service
         dst: /lib/systemd/system/otelcol.service

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -137,36 +137,10 @@ nfpms:
       rpm:
         dependencies:
           - /bin/sh
-    id: otelcol-pie
-    builds:
-      - otelcol-pie
-    formats:
-      - deb
-      - rpm
-    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
-    description: OpenTelemetry Collector - otelcol
-    license: Apache 2.0
-  - package_name: otelcol
-    contents:
-      - src: otelcol.service
-        dst: /lib/systemd/system/otelcol.service
-      - src: otelcol.conf
-        dst: /etc/otelcol/otelcol.conf
-        type: config|noreplace
-      - src: config.yaml
-        dst: /etc/otelcol/config.yaml
-        type: config|noreplace
-    scripts:
-      preinstall: preinstall.sh
-      postinstall: postinstall.sh
-      preremove: preremove.sh
-    overrides:
-      rpm:
-        dependencies:
-          - /bin/sh
     id: otelcol
     builds:
       - otelcol
+      - otelcol-pie
     formats:
       - deb
       - rpm

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -12,7 +12,7 @@ msi:
       - opentelemetry.ico
       - config.yaml
 builds:
-  - id: otelcol
+  - id: otelcol-pie
     goos:
       - darwin
       - linux

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -119,7 +119,7 @@ archives:
       - otelcol
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol
+  - package_name: otelcol-pie
     contents:
       - src: otelcol.service
         dst: /lib/systemd/system/otelcol.service

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -119,33 +119,6 @@ archives:
       - otelcol
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
-  - package_name: otelcol-pie
-    contents:
-      - src: otelcol.service
-        dst: /lib/systemd/system/otelcol.service
-      - src: otelcol.conf
-        dst: /etc/otelcol/otelcol.conf
-        type: config|noreplace
-      - src: config.yaml
-        dst: /etc/otelcol/config.yaml
-        type: config|noreplace
-    scripts:
-      preinstall: preinstall.sh
-      postinstall: postinstall.sh
-      preremove: preremove.sh
-    overrides:
-      rpm:
-        dependencies:
-          - /bin/sh
-    id: otelcol-pie
-    builds:
-      - otelcol-pie
-    formats:
-      - deb
-      - rpm
-    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
-    description: OpenTelemetry Collector - otelcol
-    license: Apache 2.0
   - package_name: otelcol
     contents:
       - src: otelcol.service

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -154,10 +154,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-386
+      - otel/opentelemetry-collector:{{ .Version }}-386
+      - otel/opentelemetry-collector:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -174,10 +174,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+      - otel/opentelemetry-collector:{{ .Version }}-amd64
+      - otel/opentelemetry-collector:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -195,10 +195,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
+      - otel/opentelemetry-collector:{{ .Version }}-armv7
+      - otel/opentelemetry-collector:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -215,10 +215,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
+      - otel/opentelemetry-collector:{{ .Version }}-arm64
+      - otel/opentelemetry-collector:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -235,10 +235,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -255,10 +255,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      - otel/opentelemetry-collector:{{ .Version }}-s390x
+      - otel/opentelemetry-collector:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -272,38 +272,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector:{{ .Version }}
+  - name_template: otel/opentelemetry-collector:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector:latest
+      - otel/opentelemetry-collector:{{ .Version }}-386
+      - otel/opentelemetry-collector:{{ .Version }}-amd64
+      - otel/opentelemetry-collector:{{ .Version }}-armv7
+      - otel/opentelemetry-collector:{{ .Version }}-arm64
+      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector:latest-386
-      - johnpeterson785/opentelemetry-collector:latest-amd64
-      - johnpeterson785/opentelemetry-collector:latest-armv7
-      - johnpeterson785/opentelemetry-collector:latest-arm64
-      - johnpeterson785/opentelemetry-collector:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
+      - otel/opentelemetry-collector:latest-386
+      - otel/opentelemetry-collector:latest-amd64
+      - otel/opentelemetry-collector:latest-armv7
+      - otel/opentelemetry-collector:latest-arm64
+      - otel/opentelemetry-collector:latest-ppc64le
+      - otel/opentelemetry-collector:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -180,10 +180,10 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-386
+      - otel/opentelemetry-collector:{{ .Version }}-386
+      - otel/opentelemetry-collector:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -200,10 +200,10 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+      - otel/opentelemetry-collector:{{ .Version }}-amd64
+      - otel/opentelemetry-collector:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -221,10 +221,10 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
+      - otel/opentelemetry-collector:{{ .Version }}-armv7
+      - otel/opentelemetry-collector:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -241,10 +241,10 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
+      - otel/opentelemetry-collector:{{ .Version }}-arm64
+      - otel/opentelemetry-collector:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -261,10 +261,10 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -281,10 +281,10 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-s390x
-      - johnpeterson785/opentelemetry-collector:latest-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      - otel/opentelemetry-collector:{{ .Version }}-s390x
+      - otel/opentelemetry-collector:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -298,38 +298,38 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: johnpeterson785/opentelemetry-collector:{{ .Version }}
+  - name_template: otel/opentelemetry-collector:{{ .Version }}
     image_templates:
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-386
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-amd64
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-armv7
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-arm64
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-ppc64le
-      - johnpeterson785/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: johnpeterson785/opentelemetry-collector:latest
+      - otel/opentelemetry-collector:{{ .Version }}-386
+      - otel/opentelemetry-collector:{{ .Version }}-amd64
+      - otel/opentelemetry-collector:{{ .Version }}-armv7
+      - otel/opentelemetry-collector:{{ .Version }}-arm64
+      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector:{{ .Version }}-s390x
+  - name_template: otel/opentelemetry-collector:latest
     image_templates:
-      - johnpeterson785/opentelemetry-collector:latest-386
-      - johnpeterson785/opentelemetry-collector:latest-amd64
-      - johnpeterson785/opentelemetry-collector:latest-armv7
-      - johnpeterson785/opentelemetry-collector:latest-arm64
-      - johnpeterson785/opentelemetry-collector:latest-ppc64le
-      - johnpeterson785/opentelemetry-collector:latest-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
+      - otel/opentelemetry-collector:latest-386
+      - otel/opentelemetry-collector:latest-amd64
+      - otel/opentelemetry-collector:latest-armv7
+      - otel/opentelemetry-collector:latest-arm64
+      - otel/opentelemetry-collector:latest-ppc64le
+      - otel/opentelemetry-collector:latest-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
+  - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest
     image_templates:
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-386
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
-      - ghcr.io/jackgopack4/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -119,6 +119,33 @@ archives:
       - otelcol
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
+  - package_name: otelcol-pie
+    contents:
+      - src: otelcol.service
+        dst: /lib/systemd/system/otelcol.service
+      - src: otelcol.conf
+        dst: /etc/otelcol/otelcol.conf
+        type: config|noreplace
+      - src: config.yaml
+        dst: /etc/otelcol/config.yaml
+        type: config|noreplace
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: otelcol-pie
+    builds:
+      - otelcol-pie
+    formats:
+      - deb
+      - rpm
+    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
+    description: OpenTelemetry Collector - otelcol
+    license: Apache 2.0
   - package_name: otelcol
     contents:
       - src: otelcol.service

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -32,7 +32,68 @@ builds:
       - goos: darwin
         goarch: arm
       - goos: darwin
+        goarch: ppc64le
+      - goos: darwin
         goarch: s390x
+      - goos: linux
+        goarch: "386"
+      - goos: linux
+        goarch: arm
+      - goos: linux
+        goarch: s390x
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: ppc64le
+      - goos: windows
+        goarch: s390x
+    dir: _build
+    binary: otelcol
+    ldflags:
+      - -s
+      - -w
+      - -buildmode=pie
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+  - id: otelcol
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm
+      - arm64
+      - ppc64le
+      - s390x
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: amd64
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: arm64
+      - goos: darwin
+        goarch: s390x
+      - goos: linux
+        goarch: amd64
+      - goos: linux
+        goarch: arm64
+      - goos: linux
+        goarch: ppc64le
+      - goos: windows
+        goarch: "386"
+      - goos: windows
+        goarch: amd64
       - goos: windows
         goarch: arm
       - goos: windows
@@ -49,11 +110,42 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
+  - id: otelcol-pie
+    builds:
+      - otelcol-pie
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol
     builds:
       - otelcol
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
+  - package_name: otelcol
+    contents:
+      - src: otelcol.service
+        dst: /lib/systemd/system/otelcol.service
+      - src: otelcol.conf
+        dst: /etc/otelcol/otelcol.conf
+        type: config|noreplace
+      - src: config.yaml
+        dst: /etc/otelcol/config.yaml
+        type: config|noreplace
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: otelcol-pie
+    builds:
+      - otelcol-pie
+    formats:
+      - deb
+      - rpm
+    maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
+    description: OpenTelemetry Collector - otelcol
+    license: Apache 2.0
   - package_name: otelcol
     contents:
       - src: otelcol.service


### PR DESCRIPTION
Currently, the collector distributions and OCB are not built as position-independent executables.
According to the [OTel Collector Security Audit](https://opentelemetry.io/blog/2024/hardening-the-collector-one/), this could cause potential vulnerabilities: https://github.com/open-telemetry/opentelemetry-collector-releases/issues/618

This PR updates the goreleaser template and the corresponding YAML files to run two separate builds for each distribution that come together for one release each; if the platform and architecture support [Internal Linking in Golang](https://pkg.go.dev/internal/platform#InternalLinkPIESupported), they are built with flag `-buildmode=pie`. If not, they are built the same way as before.

You can see the sample releases in my forked repository:
https://github.com/jackgopack4/opentelemetry-collector-releases/releases/tag/v0.114.0
https://github.com/jackgopack4/opentelemetry-collector-releases/releases/tag/cmd%2Fbuilder%2Fv0.114.0
https://hub.docker.com/r/johnpeterson785/opentelemetry-collector/tags
https://hub.docker.com/r/johnpeterson785/opentelemetry-collector-contrib/tags
https://hub.docker.com/r/johnpeterson785/opentelemetry-collector-otlp/tags
https://hub.docker.com/r/johnpeterson785/opentelemetry-collector-k8s/tags

I took the approach of generating an "ignore" list for PIE vs not-PIE and otherwise leaving everything else the same.