### PR TITLE
remove go flag from distribution build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ci: check build
 check: ensure-goreleaser-up-to-date
 
 build: go ocb
-	@./scripts/build.sh -d "${DISTRIBUTIONS}" -b ${OTELCOL_BUILDER} -g ${GO}
+	@./scripts/build.sh -d "${DISTRIBUTIONS}" -b ${OTELCOL_BUILDER}
 
 generate: generate-sources generate-goreleaser
 
@@ -20,7 +20,7 @@ generate-goreleaser: go
 	@./scripts/generate-goreleaser.sh -d "${GEN_CONFIG_DISTRIBUTIONS}" -g ${GO}
 
 generate-sources: go ocb
-	@./scripts/build.sh -d "${DISTRIBUTIONS}" -s true -b ${OTELCOL_BUILDER} -g ${GO}
+	@./scripts/build.sh -d "${DISTRIBUTIONS}" -s true -b ${OTELCOL_BUILDER}
 
 goreleaser-verify: goreleaser
 	@${GORELEASER} release --snapshot --clean

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,6 @@
 
 REPO_DIR="$( cd "$(dirname "$( dirname "${BASH_SOURCE[0]}" )")" &> /dev/null && pwd )"
 BUILDER=''
-GO=''
 
 # default values
 skipcompilation=false
@@ -13,13 +12,11 @@ do
         d) distributions=${OPTARG};;
         s) skipcompilation=${OPTARG};;
         b) BUILDER=${OPTARG};;
-        g) GO=${OPTARG};;
         *) exit 1;;
     esac
 done
 
 [[ -n "$BUILDER" ]] || BUILDER='ocb'
-[[ -n "$GO" ]] || GO='go'
 
 if [[ -z $distributions ]]; then
     echo "List of distributions to build not provided. Use '-d' to specify the names of the distributions to build. Ex.:"
@@ -40,9 +37,9 @@ do
 
     echo "Building: $distribution"
     echo "Using Builder: $(command -v "$BUILDER")"
-    echo "Using Go: $(command -v "$GO")"
+    echo "Using Go: $(command -v go)"
 
-    if "$BUILDER" --skip-compilation="${skipcompilation}" --go "$GO" --config manifest.yaml > _build/build.log 2>&1; then
+    if "$BUILDER" --skip-compilation="${skipcompilation}" --config manifest.yaml > _build/build.log 2>&1; then
         echo "✅ SUCCESS: distribution '${distribution}' built."
     else
         echo "❌ ERROR: failed to build the distribution '${distribution}'."


### PR DESCRIPTION
in https://github.com/open-telemetry/opentelemetry-collector/pull/11576 we removed flag `--go` but this script will fail if builder v0.113.0 is used to build and release v0.113.0 distributions.

Pipeline build and release should be sufficient to test this script.