### PR TITLE
Set up default renovate config with regex to handle goreleaser-pro updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,102 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "labels": [
+    "renovatebot",
+    "dependencies"
+  ],
+  "constraints": {
+    "go": "1.22.0"
+  },
+  "schedule": ["every tuesday"],
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance", "rollback", "bump", "replacement"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "prBodyNotes": [":warning: MAJOR VERSION UPDATE :warning: - please manually update this package"],
+      "labels": ["dependency-major-update"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "dockerfile deps"
+    },
+    {
+      "matchManagers": ["docker-compose"],
+      "groupName": "docker-compose deps"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions deps"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrlPrefixes": ["https://github.com/aws"],
+      "groupName": "All github.com/aws packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrlPrefixes": ["https://github.com/azure"],
+      "groupName": "All github.com/azure packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrlPrefixes": ["https://github.com/datadog"],
+      "groupName": "All github.com/datadog packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrlPrefixes": ["https://google.golang.org"],
+      "groupName": "All google.golang.org packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["golang.org/x"],
+      "groupName": "All golang.org/x packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["go.opentelemetry.io/build-tools"],
+      "groupName": "All go.opentelemetry.io/build-tools packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrlPrefixes": ["https://go.opentelemetry.io/otel"],
+      "groupName": "All go.opentelemetry.io/otel packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["cloud.google.com/go"],
+      "groupName": "All cloud.google.com/go packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrlPrefixes": ["https://github.com/googlecloudplatform"],
+      "groupName": "All github.com/googlecloudplatform packages"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrls": ["https://github.com/open-telemetry/opentelemetry-collector"],
+      "groupName": "All OpenTelemetry Collector dev packages",
+      "matchUpdateTypes": ["digest"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrls": ["https://github.com/open-telemetry/opentelemetry-collector"],
+      "groupName": "All OpenTelemetry Collector packages",
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchSourceUrls": [
+        "https://github.com/open-telemetry/opentelemetry-go-contrib"
+      ],
+      "groupName": "All opentelemetry-go-contrib packages"
+    }
   ],
   "customManagers": [
     {
@@ -15,5 +110,7 @@
       "depNameTemplate": "github.com/goreleaser/goreleaser-pro",
       "datasourceTemplate": "github-releases"
     }
-  ]
+  ],
+  "prConcurrentLimit": 200,
+  "suppressNotifications": ["prEditedNotification"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "matchStrings": [
         "goreleaser\\/goreleaser-action@[\\S\\s]+version: (?<currentValue>.*?)$"
       ],
-      "depNameTemplate": "github.com/goreleaser/goreleaser",
+      "depNameTemplate": "github.com/goreleaser/goreleaser-pro",
       "datasourceTemplate": "github-releases"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "dependencies"
   ],
   "constraints": {
-    "go": "1.22.0"
+    "go": "1.22"
   },
   "schedule": ["every tuesday"],
   "extends": ["config:recommended"],
@@ -35,18 +35,15 @@
     },
     {
       "matchManagers": ["gomod"],
-      "matchSourceUrlPrefixes": ["https://github.com/aws"],
-      "groupName": "All github.com/aws packages"
+      "matchSourceUrls": [
+        "https://github.com/open-telemetry/opentelemetry-go-contrib"
+      ],
+      "groupName": "All opentelemetry-go-contrib packages"
     },
     {
       "matchManagers": ["gomod"],
-      "matchSourceUrlPrefixes": ["https://github.com/azure"],
-      "groupName": "All github.com/azure packages"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchSourceUrlPrefixes": ["https://github.com/datadog"],
-      "groupName": "All github.com/datadog packages"
+      "matchSourceUrlPrefixes": ["https://go.opentelemetry.io/otel"],
+      "groupName": "All go.opentelemetry.io/contrib packages"
     },
     {
       "matchManagers": ["gomod"],
@@ -60,42 +57,18 @@
     },
     {
       "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["go.opentelemetry.io/collector"],
+      "groupName": "All go.opentelemetry.io/collector packages"
+    },
+    {
+      "matchManagers": ["gomod"],
       "matchPackagePrefixes": ["go.opentelemetry.io/build-tools"],
       "groupName": "All go.opentelemetry.io/build-tools packages"
     },
     {
       "matchManagers": ["gomod"],
-      "matchSourceUrlPrefixes": ["https://go.opentelemetry.io/otel"],
-      "groupName": "All go.opentelemetry.io/otel packages"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["cloud.google.com/go"],
-      "groupName": "All cloud.google.com/go packages"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchSourceUrlPrefixes": ["https://github.com/googlecloudplatform"],
-      "groupName": "All github.com/googlecloudplatform packages"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchSourceUrls": ["https://github.com/open-telemetry/opentelemetry-collector"],
-      "groupName": "All OpenTelemetry Collector dev packages",
-      "matchUpdateTypes": ["digest"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchSourceUrls": ["https://github.com/open-telemetry/opentelemetry-collector"],
-      "groupName": "All OpenTelemetry Collector packages",
-      "matchUpdateTypes": ["major", "minor", "patch"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchSourceUrls": [
-        "https://github.com/open-telemetry/opentelemetry-go-contrib"
-      ],
-      "groupName": "All opentelemetry-go-contrib packages"
+      "matchDepTypes": ["toolchain"],
+      "enabled": false
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "fileMatch": [
+        "(^|\\/).github\\/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "goreleaser\\/goreleaser-action@[\\S\\s]+version: (?<currentValue>.*?)$"
+      ],
+      "depName": "github.com/goreleaser/goreleaser",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,14 @@
   ],
   "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "(^|\\/).github\\/.*\\.ya?ml$"
       ],
       "matchStrings": [
         "goreleaser\\/goreleaser-action@[\\S\\s]+version: (?<currentValue>.*?)$"
       ],
-      "depName": "github.com/goreleaser/goreleaser",
+      "depNameTemplate": "github.com/goreleaser/goreleaser",
       "datasourceTemplate": "github-releases"
     }
   ]


### PR DESCRIPTION
This PR takes the renovate config from https://github.com/open-telemetry/opentelemetry-collector (as I found this to be mostly also applicable here, maybe a bit overkill still) and adds a custom regex manager that handles updates of the `version` field for GoReleaser inside the goreleaser-action usages.
Example of an occurrence that this should cover: https://github.com/open-telemetry/opentelemetry-collector-releases/blob/11530fd416496525d0a026be319feb442e0add3b/.github/workflows/base-release.yaml#L83-L88

Hopefully, this works for #668 but renovate config updates are hard to test before merging. The local setup didn't scream, which is a good sign. I will close the issue manually once I'm sure that this PR fixes it and otherwise provide follow-up PRs.