### PR TITLE
[chore] move partial goreleaser config to native code

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -47,6 +47,7 @@ var (
 	K8sDockerSkipArchs = map[string]bool{"arm": true, "386": true}
 	K8sGoos            = []string{"linux"}
 	K8sArchs           = []string{"amd64", "arm64", "ppc64le", "s390x"}
+	Partial            = config.Partial{By: "target"}
 )
 
 func GenerateContribBuildOnly(dist string, buildOrRest bool) config.Project {
@@ -57,6 +58,7 @@ func GenerateContribBuildOnly(dist string, buildOrRest bool) config.Project {
 		Monorepo: config.Monorepo{
 			TagPrefix: "v",
 		},
+		Partial: Partial,
 	}
 }
 
@@ -80,6 +82,7 @@ func Generate(dist string, buildOrRest bool) config.Project {
 		Monorepo: config.Monorepo{
 			TagPrefix: "v",
 		},
+		Partial: Partial,
 	}
 }
 

--- a/cmd/goreleaser/main.go
+++ b/cmd/goreleaser/main.go
@@ -43,18 +43,7 @@ func main() {
 		project = internal.Generate(*distFlag, *contribBuildOrRestFlag)
 	}
 
-	partial := map[string]any{
-		"partial": map[string]any{
-			"by": "target",
-		},
-	}
 	e := yaml.NewEncoder(os.Stdout)
-	e.SetIndent(2)
-	if err := e.Encode(partial); err != nil {
-		log.Fatal(err)
-	}
-
-	e = yaml.NewEncoder(os.Stdout)
 	e.SetIndent(2)
 	if err := e.Encode(&project); err != nil {
 		log.Fatal(err)

--- a/distributions/otelcol-contrib/.goreleaser-build.yaml
+++ b/distributions/otelcol-contrib/.goreleaser-build.yaml
@@ -1,5 +1,3 @@
-partial:
-  by: target
 version: 2
 project_name: opentelemetry-collector-releases
 builds:
@@ -41,3 +39,5 @@ builds:
       - CGO_ENABLED=0
 monorepo:
   tag_prefix: v
+partial:
+  by: target

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -1,5 +1,3 @@
-partial:
-  by: target
 version: 2
 project_name: opentelemetry-collector-releases
 env:
@@ -258,3 +256,5 @@ sboms:
     artifacts: package
 monorepo:
   tag_prefix: v
+partial:
+  by: target

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -1,5 +1,3 @@
-partial:
-  by: target
 version: 2
 project_name: opentelemetry-collector-releases
 env:
@@ -151,3 +149,5 @@ sboms:
     artifacts: package
 monorepo:
   tag_prefix: v
+partial:
+  by: target

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -1,5 +1,3 @@
-partial:
-  by: target
 version: 2
 project_name: opentelemetry-collector-releases
 env:
@@ -246,3 +244,5 @@ sboms:
     artifacts: package
 monorepo:
   tag_prefix: v
+partial:
+  by: target

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -1,5 +1,3 @@
-partial:
-  by: target
 version: 2
 project_name: opentelemetry-collector-releases
 env:
@@ -262,3 +260,5 @@ sboms:
     artifacts: package
 monorepo:
   tag_prefix: v
+partial:
+  by: target


### PR DESCRIPTION
This PR moves the `partial` setting to native goreleaser go code instead of adding the option to the generated yaml file after the fact.

Fixes #735 