### PR TITLE
[chore] Make a draft release instead of directly releasing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,5 +2,6 @@ version: 2
 monorepo:
   tag_prefix: v
 release:
+  draft: true
   header: |
     Check the [v{{.Version}} contrib changelog](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tags/v{{.Version}}) and the [v{{.Version}} core changelog](https://github.com/open-telemetry/opentelemetry-collector/releases/tags/v{{.Version}}) for changelogs on specific components.


### PR DESCRIPTION
Sets `release.draft: true`. This would allow us more control over when to announce the release.
