### PR TITLE
[chore] Create issue when nightly tests fail

### DIFF
--- a/.github/workflows/base-package-tests.yaml
+++ b/.github/workflows/base-package-tests.yaml
@@ -9,6 +9,11 @@ on:
       distribution:
         required: true
         type: string
+      issue-on-failure:
+        required: false
+        type: boolean
+        default: false
+        description: "Set to true if a GH issue should be generated upon failure"
 
 jobs:
   package-tests:
@@ -28,3 +33,29 @@ jobs:
 
       - name: Test ${{ matrix.type }} package
         run: ./scripts/package-tests/package-tests.sh ./otelcol*-SNAPSHOT-*_linux_amd64.${{ matrix.type }} ${{ inputs.distribution }}
+
+  create-issue:
+    name: Create GitHub Issue
+    runs-on: ubuntu-24.04
+    needs: [package-tests]
+    if: failure() && inputs.issue-on-failure == 'true'
+    steps:
+      - name: Formulate issue
+        id: formulate_issue
+        run: |
+          # create a markdown file that contains details about the failure
+          echo "The nightly linux package tests failed in the following GitHub actions run." > nightly-test-failure.md
+          echo "* Link to run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> nightly-test-failure.md
+          echo "* Triggered by: Nightly scheduled build" >> nightly-test-failure.md
+          echo "" >> nightly-test-failure.md
+          echo "Note: This issue was auto-generated from [base-package-tests.yaml](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/.github/workflows/base-package-tests.yaml)" >> nightly-test-failure.md
+
+      - name: Create issue on failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue create \
+            --repo open-telemetry/opentelemetry-collector-contrib \
+            --title "Nightly Linux Package Tests Failed" \
+            --body-file nightly-test-failure.md \
+            --label "release:blocker"

--- a/.github/workflows/base-package-tests.yaml
+++ b/.github/workflows/base-package-tests.yaml
@@ -36,7 +36,7 @@ jobs:
 
   create-issue:
     name: Create GitHub Issue
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [package-tests]
     if: failure() && inputs.issue-on-failure == 'true'
     steps:

--- a/.github/workflows/package-test.yaml
+++ b/.github/workflows/package-test.yaml
@@ -22,3 +22,4 @@ jobs:
     with:
       distribution: otelcol-contrib
       type: '[ "deb", "rpm" ]'
+      issue-on-failure: true


### PR DESCRIPTION
This PR adds issue creation when the nightly package tests fail. The issue will be created in the -contrib repo with the "release:blocker" label attached.

Fixes https://github.com/open-telemetry/opentelemetry-collector-releases/issues/756