### PR TITLE
Revert "[chore] build compatible distributions as PIE (#726)"

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -8,7 +8,6 @@ version: 2
 builds:
   - flags:
       - -trimpath
-      - -buildmode=pie
     ldflags:
       - -s -w -X go.opentelemetry.io/collector/cmd/builder/internal.version={{ .Version }}
     env:
@@ -137,3 +136,4 @@ sboms:
     artifacts: archive
   - id: package
     artifacts: package
+    

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -48,28 +48,7 @@ var (
 	K8sDockerSkipArchs = map[string]bool{"arm": true, "386": true}
 	K8sGoos            = []string{"linux"}
 	K8sArchs           = []string{"amd64", "arm64", "ppc64le", "s390x"}
-	AlwaysIgnored      = map[config.IgnoredBuild]bool{
-		{Goos: "darwin", Goarch: "386"}:    true,
-		{Goos: "darwin", Goarch: "arm"}:    true,
-		{Goos: "darwin", Goarch: "s390x"}:  true,
-		{Goos: "windows", Goarch: "arm"}:   true,
-		{Goos: "windows", Goarch: "arm64"}: true,
-		{Goos: "windows", Goarch: "s390x"}: true,
-	}
 )
-
-// Copied from go/src/internal/platform/supported.go, see:
-// https://cs.opensource.google/go/go/+/d7fcb5cf80953f1d63246f1ae9defa60c5ce2d76:src/internal/platform/supported.go;l=222
-func InternalLinkPIESupported(goos, goarch string) bool {
-	switch goos + "/" + goarch {
-	case "android/arm64",
-		"darwin/amd64", "darwin/arm64",
-		"linux/amd64", "linux/arm64", "linux/ppc64le",
-		"windows/386", "windows/amd64", "windows/arm", "windows/arm64":
-		return true
-	}
-	return false
-}
 
 func Generate(dist string) config.Project {
 	return config.Project{
@@ -96,59 +75,43 @@ func Generate(dist string) config.Project {
 
 func Builds(dist string) []config.Build {
 	return []config.Build{
-		Build(dist, true),
-		Build(dist, false),
+		Build(dist),
 	}
-}
-
-func generateIgnored(goos, archs []string, pie bool) []config.IgnoredBuild {
-	ignored := make([]config.IgnoredBuild, 0)
-	var build config.IgnoredBuild
-	for _, goos := range goos {
-		for _, arch := range archs {
-			build = config.IgnoredBuild{
-				Goos:   goos,
-				Goarch: arch,
-			}
-			if _, ok := AlwaysIgnored[build]; ok || !pie && InternalLinkPIESupported(goos, arch) || pie && !InternalLinkPIESupported(goos, arch) {
-				ignored = append(ignored, build)
-			}
-		}
-	}
-	return ignored
 }
 
 // Build configures a goreleaser build.
 // https://goreleaser.com/customization/build/
-func Build(dist string, pie bool) config.Build {
+func Build(dist string) config.Build {
 	var goos []string
 	var archs []string
 	var ignore []config.IgnoredBuild
 	var armVersions []string
-	id := dist
-	ldflags := []string{"-s", "-w"}
-	if pie {
-		ldflags = append(ldflags, "-buildmode=pie")
-		id = id + "-pie"
-	}
 	if dist == K8sDistro {
 		goos = K8sGoos
 		archs = K8sArchs
+		ignore = make([]config.IgnoredBuild, 0)
 		armVersions = make([]string, 0)
 	} else {
 		goos = []string{"darwin", "linux", "windows"}
 		archs = Architectures
+		ignore = []config.IgnoredBuild{
+			{Goos: "darwin", Goarch: "386"},
+			{Goos: "darwin", Goarch: "arm"},
+			{Goos: "darwin", Goarch: "s390x"},
+			{Goos: "windows", Goarch: "arm"},
+			{Goos: "windows", Goarch: "arm64"},
+			{Goos: "windows", Goarch: "s390x"},
+		}
 		armVersions = ArmVersions
 	}
-	ignore = generateIgnored(goos, archs, pie)
 	return config.Build{
-		ID:     id,
+		ID:     dist,
 		Dir:    "_build",
 		Binary: dist,
 		BuildDetails: config.BuildDetails{
 			Env:     []string{"CGO_ENABLED=0"},
 			Flags:   []string{"-trimpath"},
-			Ldflags: ldflags,
+			Ldflags: []string{"-s", "-w"},
 		},
 		Goos:   goos,
 		Goarch: archs,
@@ -159,24 +122,17 @@ func Build(dist string, pie bool) config.Build {
 
 func Archives(dist string) (r []config.Archive) {
 	return []config.Archive{
-		Archive(dist, true),
-		Archive(dist, false),
+		Archive(dist),
 	}
 }
 
 // Archive configures a goreleaser archive (tarball).
 // https://goreleaser.com/customization/archive/
-func Archive(dist string, pie bool) config.Archive {
-	id := dist
-	build := dist
-	if pie {
-		id = id + "-pie"
-		build = build + "-pie"
-	}
+func Archive(dist string) config.Archive {
 	return config.Archive{
-		ID:           id,
+		ID:           dist,
 		NameTemplate: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}",
-		Builds:       []string{build},
+		Builds:       []string{dist},
 	}
 }
 
@@ -216,7 +172,6 @@ func Packages(dist string) (r []config.NFPM) {
 // Package configures goreleaser to build a system package.
 // https://goreleaser.com/customization/nfpm/
 func Package(dist string) config.NFPM {
-	buildPie := dist + "-pie"
 	nfpmContents := config.NFPMContents{
 		{
 			Source:      fmt.Sprintf("%s.service", dist),
@@ -237,7 +192,7 @@ func Package(dist string) config.NFPM {
 	}
 	return config.NFPM{
 		ID:      dist,
-		Builds:  []string{dist, buildPie},
+		Builds:  []string{dist},
 		Formats: []string{"deb", "rpm"},
 
 		License:     "Apache 2.0",

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -12,53 +12,6 @@ msi:
       - opentelemetry.ico
       - config.yaml
 builds:
-  - id: otelcol-contrib-pie
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - "386"
-      - amd64
-      - arm
-      - arm64
-      - ppc64le
-      - s390x
-    goarm:
-      - "7"
-    ignore:
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
-      - goos: darwin
-        goarch: ppc64le
-      - goos: darwin
-        goarch: s390x
-      - goos: linux
-        goarch: "386"
-      - goos: linux
-        goarch: arm
-      - goos: linux
-        goarch: s390x
-      - goos: windows
-        goarch: arm
-      - goos: windows
-        goarch: arm64
-      - goos: windows
-        goarch: ppc64le
-      - goos: windows
-        goarch: s390x
-    dir: _build
-    binary: otelcol-contrib
-    ldflags:
-      - -s
-      - -w
-      - -buildmode=pie
-    flags:
-      - -trimpath
-    env:
-      - CGO_ENABLED=0
   - id: otelcol-contrib
     goos:
       - darwin
@@ -77,23 +30,9 @@ builds:
       - goos: darwin
         goarch: "386"
       - goos: darwin
-        goarch: amd64
-      - goos: darwin
         goarch: arm
       - goos: darwin
-        goarch: arm64
-      - goos: darwin
         goarch: s390x
-      - goos: linux
-        goarch: amd64
-      - goos: linux
-        goarch: arm64
-      - goos: linux
-        goarch: ppc64le
-      - goos: windows
-        goarch: "386"
-      - goos: windows
-        goarch: amd64
       - goos: windows
         goarch: arm
       - goos: windows
@@ -110,10 +49,6 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - id: otelcol-contrib-pie
-    builds:
-      - otelcol-contrib-pie
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol-contrib
     builds:
       - otelcol-contrib
@@ -140,7 +75,6 @@ nfpms:
     id: otelcol-contrib
     builds:
       - otelcol-contrib
-      - otelcol-contrib-pie
     formats:
       - deb
       - rpm

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -5,27 +5,6 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
 builds:
-  - id: otelcol-k8s-pie
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-      - ppc64le
-      - s390x
-    ignore:
-      - goos: linux
-        goarch: s390x
-    dir: _build
-    binary: otelcol-k8s
-    ldflags:
-      - -s
-      - -w
-      - -buildmode=pie
-    flags:
-      - -trimpath
-    env:
-      - CGO_ENABLED=0
   - id: otelcol-k8s
     goos:
       - linux
@@ -34,13 +13,6 @@ builds:
       - arm64
       - ppc64le
       - s390x
-    ignore:
-      - goos: linux
-        goarch: amd64
-      - goos: linux
-        goarch: arm64
-      - goos: linux
-        goarch: ppc64le
     dir: _build
     binary: otelcol-k8s
     ldflags:
@@ -51,10 +23,6 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - id: otelcol-k8s-pie
-    builds:
-      - otelcol-k8s-pie
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol-k8s
     builds:
       - otelcol-k8s

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -11,53 +11,6 @@ msi:
     extra_files:
       - opentelemetry.ico
 builds:
-  - id: otelcol-otlp-pie
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - "386"
-      - amd64
-      - arm
-      - arm64
-      - ppc64le
-      - s390x
-    goarm:
-      - "7"
-    ignore:
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
-      - goos: darwin
-        goarch: ppc64le
-      - goos: darwin
-        goarch: s390x
-      - goos: linux
-        goarch: "386"
-      - goos: linux
-        goarch: arm
-      - goos: linux
-        goarch: s390x
-      - goos: windows
-        goarch: arm
-      - goos: windows
-        goarch: arm64
-      - goos: windows
-        goarch: ppc64le
-      - goos: windows
-        goarch: s390x
-    dir: _build
-    binary: otelcol-otlp
-    ldflags:
-      - -s
-      - -w
-      - -buildmode=pie
-    flags:
-      - -trimpath
-    env:
-      - CGO_ENABLED=0
   - id: otelcol-otlp
     goos:
       - darwin
@@ -76,23 +29,9 @@ builds:
       - goos: darwin
         goarch: "386"
       - goos: darwin
-        goarch: amd64
-      - goos: darwin
         goarch: arm
       - goos: darwin
-        goarch: arm64
-      - goos: darwin
         goarch: s390x
-      - goos: linux
-        goarch: amd64
-      - goos: linux
-        goarch: arm64
-      - goos: linux
-        goarch: ppc64le
-      - goos: windows
-        goarch: "386"
-      - goos: windows
-        goarch: amd64
       - goos: windows
         goarch: arm
       - goos: windows
@@ -109,10 +48,6 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - id: otelcol-otlp-pie
-    builds:
-      - otelcol-otlp-pie
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol-otlp
     builds:
       - otelcol-otlp
@@ -136,7 +71,6 @@ nfpms:
     id: otelcol-otlp
     builds:
       - otelcol-otlp
-      - otelcol-otlp-pie
     formats:
       - deb
       - rpm

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -12,53 +12,6 @@ msi:
       - opentelemetry.ico
       - config.yaml
 builds:
-  - id: otelcol-pie
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - "386"
-      - amd64
-      - arm
-      - arm64
-      - ppc64le
-      - s390x
-    goarm:
-      - "7"
-    ignore:
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
-      - goos: darwin
-        goarch: ppc64le
-      - goos: darwin
-        goarch: s390x
-      - goos: linux
-        goarch: "386"
-      - goos: linux
-        goarch: arm
-      - goos: linux
-        goarch: s390x
-      - goos: windows
-        goarch: arm
-      - goos: windows
-        goarch: arm64
-      - goos: windows
-        goarch: ppc64le
-      - goos: windows
-        goarch: s390x
-    dir: _build
-    binary: otelcol
-    ldflags:
-      - -s
-      - -w
-      - -buildmode=pie
-    flags:
-      - -trimpath
-    env:
-      - CGO_ENABLED=0
   - id: otelcol
     goos:
       - darwin
@@ -77,23 +30,9 @@ builds:
       - goos: darwin
         goarch: "386"
       - goos: darwin
-        goarch: amd64
-      - goos: darwin
         goarch: arm
       - goos: darwin
-        goarch: arm64
-      - goos: darwin
         goarch: s390x
-      - goos: linux
-        goarch: amd64
-      - goos: linux
-        goarch: arm64
-      - goos: linux
-        goarch: ppc64le
-      - goos: windows
-        goarch: "386"
-      - goos: windows
-        goarch: amd64
       - goos: windows
         goarch: arm
       - goos: windows
@@ -110,10 +49,6 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - id: otelcol-pie
-    builds:
-      - otelcol-pie
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
   - id: otelcol
     builds:
       - otelcol
@@ -140,7 +75,6 @@ nfpms:
     id: otelcol
     builds:
       - otelcol
-      - otelcol-pie
     formats:
       - deb
       - rpm


### PR DESCRIPTION
This reverts commit 2dbb61e82074e956e4ce2c47f2629972e2e9ed97.

Related to https://github.com/open-telemetry/opentelemetry-collector-releases/issues/783