### PR TITLE
[chore] Add jackgopack4 as a releases approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Approvers ([@open-telemetry/collector-releases-approvers](https://github.com/org
 - [Christos Markou](https://github.com/ChrsMark), Elastic
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google
+- [John L. Peterson (Jack)](https://github.com/jackgopack4), Datadog
 - [Matt Wear](https://github.com/mwear), Lightstep
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 


### PR DESCRIPTION
Adds @jackgopack4 after majority approval from the contrib maintainers. 

Jack is one of the top 5 contributors to this repository on the past 6 months and has also contributed in other areas of the Collector. Thanks Jack for your contributions and congratulations on the promotion!