### PR TITLE
[chore] Add mowies as releases approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Approvers ([@open-telemetry/collector-releases-approvers](https://github.com/org
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google
 - [Matt Wear](https://github.com/mwear), Lightstep
+- [Moritz Wiesinger](https://github.com/mowies), Dynatrace
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 
 Emeritus Approvers:


### PR DESCRIPTION
Adds @mowies as a member of releases approvers, after majority approval by the contrib maintainers. 

Moritz is the top contributor to this repository in the past 6 months, and has also contributed in other areas of the Collector. Thanks Moritz for your contributions and congratulations on the promotion!