### PR TITLE
[chore] Update codeowners according to releases-approvers RFC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,9 @@
 
 * @open-telemetry/collector-contrib-approvers
 
+# Files owned by collector-releases-approvers
+.github/workflows/base-release.yaml    @open-telemetry/collector-contrib-approvers @open-telemetry/collector-releases-approvers
+.github/workflows/builder-release.yaml @open-telemetry/collector-contrib-approvers @open-telemetry/collector-releases-approvers
+.github/workflows/release-*.yaml       @open-telemetry/collector-contrib-approvers @open-telemetry/collector-releases-approvers
+
 distributions/otelcol-k8s/ @open-telemetry/collector-contrib-approvers @open-telemetry/helm-approvers @open-telemetry/operator-approvers


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds the releases-approvers user group as codeowners for all files related to the release.

<!-- Issue number if applicable -->
#### Link to tracking issue
Parf of https://github.com/open-telemetry/opentelemetry-collector/pull/11577



<!--Describe the documentation added.-->
#### Documentation
https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/release-approvers.md

<!--Please delete paragraphs that you did not use before submitting.-->
