### PR TITLE
Added BMC Helix exporter to otelcol-contrib releases

### DIFF
--- a/.chloggen/add_bmchelix_to_otelcol-contrib.yaml
+++ b/.chloggen/add_bmchelix_to_otelcol-contrib.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: bmchelixexporter
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add bmchelix exporter to otelcol-contrib releases
+
+# One or more tracking issues or pull requests related to the change
+issues: [822]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -49,6 +49,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.119.0


### PR DESCRIPTION
* Updated manifest.yaml
* Added a changelog note

#### References
- OpenTelemetry Collector Contrib PR introducing the exporter: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37752)
- OpenTelemetry Collector Contrib Exporter Documentation: [BMC Helix Exporter Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/bmchelixexporter)
- OpenTelemetry Collector Contrib issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36773

#### Link to tracking issue
Fixes #822