### PR TITLE
[chore] Remove unneeded build combinations and inconsistencies

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -41,6 +41,10 @@ jobs:
             GOARCH: arm
           - GOOS: windows
             GOARCH: s390x
+          - GOOS: darwin
+            GOARCH: ppc64le
+          - GOOS: windows
+            GOARCH: ppc64le
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -28,16 +28,16 @@ jobs:
             GOARCH: "386"
           - GOOS: darwin
             GOARCH: s390x
-          - GOOS: darwin
-            GOARCH: arm
-          - GOOS: darwin
-            GOARCH: ppc64le
           - GOOS: windows
             GOARCH: arm64
+          - GOOS: darwin
+            GOARCH: arm
           - GOOS: windows
             GOARCH: s390x
           - GOOS: windows
             GOARCH: arm
+          - GOOS: darwin
+            GOARCH: ppc64le
           - GOOS: windows
             GOARCH: ppc64le
     runs-on: ubuntu-24.04

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -28,14 +28,18 @@ jobs:
             GOARCH: "386"
           - GOOS: darwin
             GOARCH: s390x
-          - GOOS: windows
-            GOARCH: arm64
           - GOOS: darwin
             GOARCH: arm
+          - GOOS: darwin
+            GOARCH: ppc64le
+          - GOOS: windows
+            GOARCH: arm64
+          - GOOS: windows
+            GOARCH: s390x
           - GOOS: windows
             GOARCH: arm
           - GOOS: windows
-            GOARCH: s390x
+            GOARCH: ppc64le
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -33,9 +33,9 @@ jobs:
           - GOOS: darwin
             GOARCH: arm
           - GOOS: windows
-            GOARCH: s390x
-          - GOOS: windows
             GOARCH: arm
+          - GOOS: windows
+            GOARCH: s390x
           - GOOS: darwin
             GOARCH: ppc64le
           - GOOS: windows

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -1,4 +1,4 @@
-name: Builder - Release
+name: Release Builder
 on:
   push:
     tags:

--- a/.github/workflows/builder-testbuild.yaml
+++ b/.github/workflows/builder-testbuild.yaml
@@ -1,4 +1,4 @@
-name: Builder - Check and Test Build
+name: CI - Builder
 
 on:
   merge_group: 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,7 @@
 # or if performing maintance on the Changelog, add either \"[chore]\" to the title of
 # the pull request or add the \"Skip Changelog\" label to disable this action.
 
-name: changelog
+name: Changelog
 
 on:
   pull_request:

--- a/.github/workflows/ci-goreleaser-contrib.yaml
+++ b/.github/workflows/ci-goreleaser-contrib.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration - Contrib - GoReleaser
+name: CI - Contrib - GoReleaser
 
 on:
   merge_group: 
@@ -25,7 +25,7 @@ on:
 
 jobs:
   check-goreleaser:
-    name: Continuous Integration - Contrib - GoReleaser
+    name: CI - Contrib - GoReleaser
     uses: ./.github/workflows/base-ci-goreleaser.yaml
     with:
       distribution: otelcol-contrib

--- a/.github/workflows/ci-goreleaser-core.yaml
+++ b/.github/workflows/ci-goreleaser-core.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration - Core - GoReleaser
+name: CI - Core - GoReleaser
 
 on:
   merge_group: 
@@ -25,7 +25,7 @@ on:
 
 jobs:
   check-goreleaser:
-    name: Continuous Integration - Core - GoReleaser
+    name: CI - Core - GoReleaser
     uses: ./.github/workflows/base-ci-goreleaser.yaml
     with:
       distribution: otelcol

--- a/.github/workflows/ci-goreleaser-k8s.yaml
+++ b/.github/workflows/ci-goreleaser-k8s.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration - k8s - GoReleaser
+name: CI - k8s - GoReleaser
 
 on:
   merge_group: 
@@ -25,7 +25,7 @@ on:
 
 jobs:
   check-goreleaser:
-    name: Continuous Integration - k8s - GoReleaser
+    name: CI - k8s - GoReleaser
     uses: ./.github/workflows/base-ci-goreleaser.yaml
     with:
       distribution: otelcol-k8s

--- a/.github/workflows/ci-goreleaser-otlp.yaml
+++ b/.github/workflows/ci-goreleaser-otlp.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration - OTLP - GoReleaser
+name: CI - OTLP - GoReleaser
 
 on:
   merge_group: 
@@ -25,7 +25,7 @@ on:
 
 jobs:
   check-goreleaser:
-    name: Continuous Integration - OTLP - GoReleaser
+    name: CI - OTLP - GoReleaser
     uses: ./.github/workflows/base-ci-goreleaser.yaml
     with:
       distribution: otelcol-otlp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI - Binaries
 
 on:
   merge_group: 

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	baseArchs   = []string{"386", "amd64", "arm", "arm64", "ppc64le", "s390x"}
-	winArchs    = []string{"386", "amd64", "arm64", "ppc64le"}
+	winArchs    = []string{"386", "amd64", "arm64"}
 	darwinArchs = []string{"amd64", "arm64"}
 	k8sArchs    = []string{"amd64", "arm64", "ppc64le", "s390x"}
 
@@ -52,7 +52,7 @@ var (
 		d.buildConfigs = []buildConfig{
 			&fullBuildConfig{targetOS: "linux", targetArch: baseArchs, armVersion: []string{"7"}, ppc64Version: []string{"power8"}},
 			&fullBuildConfig{targetOS: "darwin", targetArch: darwinArchs},
-			&fullBuildConfig{targetOS: "windows", targetArch: winArchs, ppc64Version: []string{"power8"}},
+			&fullBuildConfig{targetOS: "windows", targetArch: winArchs},
 		}
 		d.containerImages = newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"})
 		d.containerImageManifests = newContainerImageManifests(d.name, "linux", baseArchs)
@@ -63,7 +63,7 @@ var (
 		d.buildConfigs = []buildConfig{
 			&fullBuildConfig{targetOS: "linux", targetArch: baseArchs, armVersion: []string{"7"}, ppc64Version: []string{"power8"}},
 			&fullBuildConfig{targetOS: "darwin", targetArch: darwinArchs},
-			&fullBuildConfig{targetOS: "windows", targetArch: winArchs, ppc64Version: []string{"power8"}},
+			&fullBuildConfig{targetOS: "windows", targetArch: winArchs},
 		}
 		d.containerImages = newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"})
 		d.containerImageManifests = newContainerImageManifests(d.name, "linux", baseArchs)

--- a/distributions/otelcol-contrib/.goreleaser-build.yaml
+++ b/distributions/otelcol-contrib/.goreleaser-build.yaml
@@ -43,7 +43,6 @@ builds:
       - "386"
       - amd64
       - arm64
-      - ppc64le
     dir: _build
     binary: otelcol-contrib
     ldflags:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -54,7 +54,6 @@ builds:
       - "386"
       - amd64
       - arm64
-      - ppc64le
     goarm:
       - "7"
     goppc64:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -51,8 +51,6 @@ builds:
       - "386"
       - amd64
       - arm64
-    goppc64:
-      - power8
     dir: _build
     binary: otelcol-otlp
     ldflags:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -51,7 +51,6 @@ builds:
       - "386"
       - amd64
       - arm64
-      - ppc64le
     goppc64:
       - power8
     dir: _build

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -52,7 +52,6 @@ builds:
       - "386"
       - amd64
       - arm64
-      - ppc64le
     goppc64:
       - power8
     dir: _build

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -52,8 +52,6 @@ builds:
       - "386"
       - amd64
       - arm64
-    goppc64:
-      - power8
     dir: _build
     binary: otelcol
     ldflags:


### PR DESCRIPTION
### This PR
- removes the build combinations darwin/ppc64le and windows/ppc64le because they are not supported by Go and no artifacts of any sort are generated from them.
- makes pipeline naming more consistent
  - Continuous Integration -> CI
  - renamed builder pipelines to adhere to same naming scheme as collector distros


Fixes #838