### PR TITLE
[chore] fix nightly package tests

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: "[Nightly] Move downloaded artifact"
         if: inputs.distribution == 'otelcol-contrib' && inputs.nightly == true && matrix.GOARCH == 'amd64' && matrix.GOOS == 'linux'
-        run: mv otelcontribcol_linux_amd64 distributions/otelcol-contrib/artifacts/otelcol-contrib_linux_amd64_v1/otelcol-contrib
+        run: mv otelcontribcol_linux_amd64 distributions/otelcol-contrib/artifacts/otelcol-contrib-linux_linux_amd64_v1/otelcol-contrib
 
       - name: Generate the sources for ${{ inputs.distribution }}
         if: inputs.nightly != true


### PR DESCRIPTION
This PR fixes the broken nightly package test pipeline by giving the prebuilt collector binary the correct name that is expected in https://github.com/open-telemetry/opentelemetry-collector-releases/blob/20955855e2eb5bcce613a89f22d393b4ec1d250a/distributions/otelcol-contrib/.goreleaser.yaml#L34

My guess is that https://github.com/open-telemetry/opentelemetry-collector-releases/pull/797 changed the path at which the prebuilt collector binary is expected and that was not adapted in the nightly pipelines steps accordingly.