### PR TITLE
[chore] ignore ppc64le for unsupported platforms

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -23,6 +23,10 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+      - goos: windows
+        goarch: ppc64le
+      - goos: darwin
+goarch: ppc64le
     binary: ocb
 dockers:
   - goos: linux


### PR DESCRIPTION
This is based on the comment here: https://github.com/open-telemetry/opentelemetry-collector-releases/pull/858/files#r1982998320