### PR TITLE
[chore] only mark collector release as latest

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -103,6 +103,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
 release:
+  make_latest: false
   github:
     owner: open-telemetry
     name: opentelemetry-collector-releases

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -103,7 +103,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-ppc64le
 release:
-  mark_latest: false
+  make_latest: false
   github:
     owner: open-telemetry
     name: opentelemetry-collector-releases

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -103,6 +103,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-ppc64le
 release:
+  mark_latest: false
   github:
     owner: open-telemetry
     name: opentelemetry-collector-releases


### PR DESCRIPTION
This PR turns of marking OCB releases as latest on github. Nothing needs to be done on the other configs, since the setting is enabled by default, so the usual collector releases should be marked as latest by default.

Fixes #818