### PR TITLE
[feat] Add Windows 2019 and 2022 container image (amd64 only)

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -12,6 +12,10 @@ on:
       goarch:
         required: true
         type: string
+      runner_os:
+        required: false
+        type: string
+        default: ubuntu-24.04
 
 env:
   # renovate: datasource=github-tags depName=goreleaser-pro packageName=goreleaser/goreleaser-pro
@@ -21,26 +25,18 @@ jobs:
   prepare:
     strategy:
       matrix:
-        GOOS: ${{ fromJSON( inputs.goos) }}
-        GOARCH: ${{ fromJSON( inputs.goarch) }}
+        GOOS: ${{ fromJSON(inputs.goos) }}
+        GOARCH: ${{ fromJSON(inputs.goarch) }}
         exclude:
           - GOOS: darwin
             GOARCH: "386"
           - GOOS: darwin
             GOARCH: s390x
-          - GOOS: windows
-            GOARCH: arm64
-          - GOOS: darwin
-            GOARCH: arm
-          - GOOS: windows
-            GOARCH: arm
-          - GOOS: windows
-            GOARCH: s390x
           - GOOS: darwin
             GOARCH: ppc64le
-          - GOOS: windows
-            GOARCH: ppc64le
-    runs-on: ubuntu-24.04
+          - GOOS: darwin
+            GOARCH: arm
+    runs-on: ${{ inputs.runner_os }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -52,21 +48,27 @@ jobs:
       - uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        if: runner.os != 'Windows'
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x
 
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        if: runner.os != 'Windows'
+
+        # Fix slow Go compile and cache restore
+        # See https://github.com/actions/setup-go/pull/515
+      - name: Fix slow setup-go cache restore in Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "GOCACHE=D:\gocache" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "GOMODCACHE=D:\gomodcache" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "GOTMPDIR=D:\gotmp" | Out-File -FilePath $env:GITHUB_ENV -Append
+          mkdir D:\gotmp
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: "~1.24"
           check-latest: true
-
-      - name: Setup wixl # Required to build MSI packages for Windows
-        if: ${{ matrix.GOOS == 'windows' && ( matrix.GOARCH == '386' || matrix.GOARCH == 'amd64') }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wixl
 
       - name: Generate distribution sources
         run: make generate-sources
@@ -115,9 +117,13 @@ jobs:
         if: inputs.distribution == 'otelcol-contrib'
         run: mv distributions/otelcol-contrib/dist/**/* distributions/otelcol-contrib/artifacts/
 
-      - name: Show built or downloaded content
-        if: inputs.distribution == 'otelcol-contrib'
+      - name: Show built or downloaded content (Linux)
+        if: inputs.distribution == 'otelcol-contrib' && runner.os != 'Windows'
         run: ls -laR distributions/otelcol-contrib/artifacts
+
+      - name: Show built or downloaded content (Windows)
+        if: inputs.distribution == 'otelcol-contrib' && runner.os == 'Windows'
+        run: ls -Path distributions/otelcol-contrib/artifacts -Force -Recurse | Format-List
 
       - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
@@ -141,7 +147,7 @@ jobs:
 
   release:
     name: ${{ inputs.distribution }} Release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_os }}
     needs: prepare
 
     permissions:
@@ -159,10 +165,22 @@ jobs:
       - uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        if: runner.os != 'Windows'
         with:
           platforms: arm64,ppc64le,s390x
 
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        if: runner.os != 'Windows'
+
+        # Fix slow Go compile and cache restore
+        # See https://github.com/actions/setup-go/pull/515
+      - name: Fix slow setup-go cache restore in Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "GOCACHE=D:\gocache" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "GOMODCACHE=D:\gomodcache" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "GOTMPDIR=D:\gotmp" | Out-File -FilePath $env:GITHUB_ENV -Append
+          mkdir D:\gotmp
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
@@ -170,13 +188,33 @@ jobs:
           check-latest: true
 
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        if: runner.os == 'Windows'
         with:
-          pattern: artifacts-${{ inputs.distribution }}-*
+          pattern: artifacts-${{ inputs.distribution }}-windows-*
+          path: distributions/${{ inputs.distribution }}/dist
+          merge-multiple: true
+
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        if: runner.os != 'Windows'
+        with:
+          pattern: artifacts-${{ inputs.distribution }}-darwin-*
+          path: distributions/${{ inputs.distribution }}/dist
+          merge-multiple: true
+
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        if: runner.os != 'Windows'
+        with:
+          pattern: artifacts-${{ inputs.distribution }}-linux-*
           path: distributions/${{ inputs.distribution }}/dist
           merge-multiple: true
 
       - name: Display structure of downloaded files
+        if: runner.os != 'Windows'
         run: ls -R distributions/${{ inputs.distribution }}/dist
+
+      - name: Display structure of downloaded files (Windows)
+        if: runner.os == 'Windows'
+        run: ls -Path distributions/${{ inputs.distribution }}/dist -Force -Recurse | Format-List
 
       - name: Log into Docker.io
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/release-contrib.yaml
+++ b/.github/workflows/release-contrib.yaml
@@ -10,7 +10,17 @@ jobs:
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol-contrib
-      goos: '[ "linux", "windows", "darwin" ]'
+      goos: '[ "linux", "darwin" ]'
       goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+    secrets: inherit
+    permissions: write-all
+  release-windows:
+    name: Release Contrib (Windows)
+    uses: ./.github/workflows/base-release.yaml
+    with:
+      distribution: otelcol-contrib
+      goos: '[ "windows" ]'
+      goarch: '[ "386", "amd64" ]'
+      runner_os: windows-2022
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-core.yaml
+++ b/.github/workflows/release-core.yaml
@@ -10,7 +10,17 @@ jobs:
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol
-      goos: '[ "linux", "windows", "darwin" ]'
+      goos: '[ "linux", "darwin" ]'
       goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+    secrets: inherit
+    permissions: write-all
+  release-windows:
+    name: Release Core (Windows)
+    uses: ./.github/workflows/base-release.yaml
+    with:
+      distribution: otelcol
+      goos: '[ "windows" ]'
+      goarch: '[ "386", "amd64" ]'
+      runner_os: windows-2022
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-k8s.yaml
+++ b/.github/workflows/release-k8s.yaml
@@ -14,3 +14,13 @@ jobs:
       goarch: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
     secrets: inherit
     permissions: write-all
+  release-windows:
+    name: Release k8s (Windows)
+    uses: ./.github/workflows/base-release.yaml
+    with:
+      distribution: otelcol-k8s
+      goos: '[ "windows" ]'
+      goarch: '[ "386", "amd64" ]'
+      runner_os: windows-2022
+    secrets: inherit
+    permissions: write-all

--- a/.github/workflows/release-otlp.yaml
+++ b/.github/workflows/release-otlp.yaml
@@ -10,7 +10,17 @@ jobs:
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol-otlp
-      goos: '[ "linux", "windows", "darwin" ]'
+      goos: '[ "linux", "darwin" ]'
       goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+    secrets: inherit
+    permissions: write-all
+  release-windows:
+    name: Release OTLP (Windows)
+    uses: ./.github/workflows/base-release.yaml
+    with:
+      distribution: otelcol-otlp
+      goos: '[ "windows" ]'
+      goarch: '[ "386", "amd64" ]'
+      runner_os: windows-2022
     secrets: inherit
     permissions: write-all

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -22,6 +22,7 @@ package internal
 import (
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/goreleaser/goreleaser-pro/v2/pkg/config"
@@ -40,10 +41,11 @@ const (
 )
 
 var (
-	baseArchs   = []string{"386", "amd64", "arm", "arm64", "ppc64le", "s390x"}
-	winArchs    = []string{"386", "amd64", "arm64"}
-	darwinArchs = []string{"amd64", "arm64"}
-	k8sArchs    = []string{"amd64", "arm64", "ppc64le", "s390x"}
+	baseArchs         = []string{"386", "amd64", "arm", "arm64", "ppc64le", "s390x"}
+	winArchs          = []string{"386", "amd64", "arm64"}
+	winContainerArchs = []string{"amd64"}
+	darwinArchs       = []string{"amd64", "arm64"}
+	k8sArchs          = []string{"amd64", "arm64", "ppc64le", "s390x"}
 
 	imageRepos = []string{dockerHub, ghcr}
 
@@ -54,8 +56,14 @@ var (
 			&fullBuildConfig{targetOS: "darwin", targetArch: darwinArchs},
 			&fullBuildConfig{targetOS: "windows", targetArch: winArchs},
 		}
-		d.containerImages = newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"})
-		d.containerImageManifests = newContainerImageManifests(d.name, "linux", baseArchs)
+		d.containerImages = slices.Concat(
+			newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+		)
+		d.containerImageManifests = slices.Concat(
+			newContainerImageManifests(d.name, "linux", baseArchs, containerImageOptions{}),
+		)
 	}).WithPackagingDefaults().WithDefaultConfigIncluded().Build()
 
 	// otlp distro
@@ -65,8 +73,14 @@ var (
 			&fullBuildConfig{targetOS: "darwin", targetArch: darwinArchs},
 			&fullBuildConfig{targetOS: "windows", targetArch: winArchs},
 		}
-		d.containerImages = newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"})
-		d.containerImageManifests = newContainerImageManifests(d.name, "linux", baseArchs)
+		d.containerImages = slices.Concat(
+			newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+		)
+		d.containerImageManifests = slices.Concat(
+			newContainerImageManifests(d.name, "linux", baseArchs, containerImageOptions{}),
+		)
 	}).WithPackagingDefaults().Build()
 
 	// contrib distro
@@ -94,8 +108,14 @@ var (
 				},
 			},
 		}
-		d.containerImages = newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"})
-		d.containerImageManifests = newContainerImageManifests(d.name, "linux", baseArchs)
+		d.containerImages = slices.Concat(
+			newContainerImages(d.name, "linux", baseArchs, containerImageOptions{armVersion: "7"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+		)
+		d.containerImageManifests = slices.Concat(
+			newContainerImageManifests(d.name, "linux", baseArchs, containerImageOptions{}),
+		)
 	}).WithPackagingDefaults().WithDefaultConfigIncluded().Build()
 
 	// contrib build-only project
@@ -111,9 +131,16 @@ var (
 	k8sDist = newDistributionBuilder(k8sDistro).WithConfigFunc(func(d *distribution) {
 		d.buildConfigs = []buildConfig{
 			&fullBuildConfig{targetOS: "linux", targetArch: k8sArchs, ppc64Version: []string{"power8"}},
+			&fullBuildConfig{targetOS: "windows", targetArch: winContainerArchs},
 		}
-		d.containerImages = newContainerImages(d.name, "linux", k8sArchs, containerImageOptions{})
-		d.containerImageManifests = newContainerImageManifests(d.name, "linux", k8sArchs)
+		d.containerImages = slices.Concat(
+			newContainerImages(d.name, "linux", k8sArchs, containerImageOptions{armVersion: "7"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
+			newContainerImages(d.name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+		)
+		d.containerImageManifests = slices.Concat(
+			newContainerImageManifests(d.name, "linux", k8sArchs, containerImageOptions{}),
+		)
 	}).WithDefaultArchives().WithDefaultChecksum().WithDefaultSigns().WithDefaultDockerSigns().WithDefaultSBOMs().Build()
 )
 
@@ -368,7 +395,10 @@ func (d *distribution) BuildProject() config.Project {
 
 	return config.Project{
 		ProjectName: "opentelemetry-collector-releases",
-		Checksum:    d.checksum,
+		Release: config.Release{
+			ReplaceExistingArtifacts: true,
+		},
+		Checksum: d.checksum,
 		Env: []string{
 			"COSIGN_YES=true",
 			"LD_FLAGS=-s -w",
@@ -392,8 +422,14 @@ func (d *distribution) BuildProject() config.Project {
 	}
 }
 
-func newContainerImageManifests(dist, os string, archs []string) []config.DockerManifest {
+func newContainerImageManifests(dist, os string, archs []string, opts containerImageOptions) []config.DockerManifest {
 	tags := []string{`{{ .Version }}`, "latest"}
+	if os == "windows" {
+		for i, tag := range tags {
+			tags[i] = fmt.Sprintf("%s-%s-%s", tag, os, opts.winVersion)
+		}
+	}
+
 	var r []config.DockerManifest
 	for _, imageRepo := range imageRepos {
 		for _, tag := range tags {
@@ -509,6 +545,13 @@ func dockerImageWithOS(dist, os, arch string, opts containerImageOptions) config
 	if arch == armArch {
 		imageConfig.Goarm = opts.armVersion
 	}
+	if os == "windows" {
+		imageConfig.BuildFlagTemplates = slices.Insert(
+			imageConfig.BuildFlagTemplates, 1, fmt.Sprintf("--build-arg=WIN_VERSION=%s", opts.winVersion),
+		)
+		imageConfig.Dockerfile = "Windows.dockerfile"
+		imageConfig.Use = "docker"
+	}
 	return imageConfig
 }
 
@@ -523,6 +566,8 @@ func (o *osArch) buildPlatform() string {
 		case armArch:
 			return fmt.Sprintf("linux/arm/v%s", o.version)
 		}
+	case "windows":
+		return fmt.Sprintf("windows/%s", o.arch)
 	}
 	return fmt.Sprintf("linux/%s", o.arch)
 }
@@ -534,6 +579,8 @@ func (o *osArch) imageTag() string {
 		case armArch:
 			return fmt.Sprintf("armv%s", o.version)
 		}
+	case "windows":
+		return fmt.Sprintf("windows-%s-%s", o.version, o.arch)
 	}
 	return o.arch
 }
@@ -576,10 +623,14 @@ func osDockerManifest(prefix, version, dist, os string, archs []string) config.D
 		}
 	}
 
-	return config.DockerManifest{
+	manifest := config.DockerManifest{
 		NameTemplate:   fmt.Sprintf("%s/%s:%s", prefix, imageName(dist), version),
 		ImageTemplates: imageTemplates,
 	}
+	if os == "windows" {
+		manifest.SkipPush = "{{ not (eq .Runtime.Goos \"windows\") }}"
+	}
+	return manifest
 }
 
 func armVersions(dist string) []string {
@@ -592,14 +643,4 @@ func armVersions(dist string) []string {
 // imageName translates a distribution name to a container image name.
 func imageName(dist string) string {
 	return strings.Replace(dist, binaryNamePrefix, imageNamePrefix, 1)
-}
-
-// archName translates architecture to docker platform names.
-func archName(arch, armVersion string) string {
-	switch arch {
-	case armArch:
-		return fmt.Sprintf("%s/v%s", arch, armVersion)
-	default:
-		return arch
-	}
 }

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -547,10 +547,13 @@ func dockerImageWithOS(dist, os, arch string, opts containerImageOptions) config
 	}
 	if os == "windows" {
 		imageConfig.BuildFlagTemplates = slices.Insert(
-			imageConfig.BuildFlagTemplates, 1, fmt.Sprintf("--build-arg=WIN_VERSION=%s", opts.winVersion),
+			imageConfig.BuildFlagTemplates, 1,
+			fmt.Sprintf("--build-arg=WIN_VERSION=%s", opts.winVersion),
 		)
 		imageConfig.Dockerfile = "Windows.dockerfile"
 		imageConfig.Use = "docker"
+		imageConfig.SkipBuild = "{{ not (eq .Runtime.Goos \"windows\") }}"
+		imageConfig.SkipPush = "{{ not (eq .Runtime.Goos \"windows\") }}"
 	}
 	return imageConfig
 }

--- a/distributions/otelcol-contrib/.goreleaser-build.yaml
+++ b/distributions/otelcol-contrib/.goreleaser-build.yaml
@@ -5,6 +5,8 @@ env:
   - LD_FLAGS=-s -w
   - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+release:
+  replace_existing_artifacts: true
 builds:
   - id: otelcol-contrib-linux
     goos:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -232,6 +232,8 @@ dockers:
       - otel/opentelemetry-collector-contrib:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-windows-2019-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -253,6 +255,8 @@ dockers:
       - otel/opentelemetry-collector-contrib:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-windows-2022-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     extra_files:
       - config.yaml
     build_flag_templates:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -5,6 +5,8 @@ env:
   - LD_FLAGS=-s -w
   - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+release:
+  replace_existing_artifacts: true
 msi:
   - id: otelcol-contrib
     name: otelcol-contrib_{{ .Version }}_{{ .Os }}_{{ .MsiArch }}
@@ -222,6 +224,48 @@ dockers:
       - --label=org.opencontainers.image.source={{.GitURL}}
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-windows-2019-amd64
+      - otel/opentelemetry-collector-contrib:latest-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-windows-2019-amd64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2019
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-windows-2022-amd64
+      - otel/opentelemetry-collector-contrib:latest-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-windows-2022-amd64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2022
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
 docker_manifests:
   - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:

--- a/distributions/otelcol-contrib/Windows.dockerfile
+++ b/distributions/otelcol-contrib/Windows.dockerfile
@@ -1,0 +1,12 @@
+# escape=`
+ARG WIN_VERSION=2019
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+
+COPY otelcol-contrib.exe ./otelcol-contrib.exe
+COPY config.yaml ./config.yaml
+
+ENV NO_WINDOWS_SERVICE=1
+
+ENTRYPOINT ["otelcol-contrib.exe"]
+CMD ["--config", "config.yaml"]
+EXPOSE 4317 4318 55678 55679

--- a/distributions/otelcol-contrib/windows-installer.wxs
+++ b/distributions/otelcol-contrib/windows-installer.wxs
@@ -43,7 +43,7 @@
                <Component Id="ApplicationComponent" Guid="1207C3C4-1830-4DC8-8A7B-2BD7DBE45BC3">
                   <!-- Files to include -->
                   <File
-                     Id="{{ .Binary }}.exe"
+                     Id="{{ replace .Binary "-"  "_"}}.exe"
                      Name="{{ .Binary }}.exe"
                      Source="{{ .Binary }}.exe"
                      KeyPath="yes"/>

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -124,6 +124,8 @@ dockers:
       - otel/opentelemetry-collector-k8s:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-windows-2019-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2019
@@ -143,6 +145,8 @@ dockers:
       - otel/opentelemetry-collector-k8s:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-windows-2022-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2022

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -5,6 +5,8 @@ env:
   - LD_FLAGS=-s -w
   - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+release:
+  replace_existing_artifacts: true
 builds:
   - id: otelcol-k8s-linux
     goos:
@@ -22,10 +24,22 @@ builds:
       - '{{ .Env.LD_FLAGS }}'
     flags:
       - '{{ .Env.BUILD_FLAGS }}'
+  - id: otelcol-k8s-windows
+    goos:
+      - windows
+    goarch:
+      - amd64
+    dir: _build
+    binary: otelcol-k8s
+    ldflags:
+      - '{{ .Env.LD_FLAGS }}'
+    flags:
+      - '{{ .Env.BUILD_FLAGS }}'
 archives:
   - id: otelcol-k8s
     builds:
       - otelcol-k8s-linux
+      - otelcol-k8s-windows
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 checksum:
   name_template: '{{ .ProjectName }}_otelcol-k8s_checksums.txt'
@@ -102,6 +116,44 @@ dockers:
       - --label=org.opencontainers.image.source={{.GitURL}}
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-windows-2019-amd64
+      - otel/opentelemetry-collector-k8s:latest-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-windows-2019-amd64
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2019
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-windows-2022-amd64
+      - otel/opentelemetry-collector-k8s:latest-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-windows-2022-amd64
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2022
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
 docker_manifests:
   - name_template: otel/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:

--- a/distributions/otelcol-k8s/Windows.dockerfile
+++ b/distributions/otelcol-k8s/Windows.dockerfile
@@ -1,0 +1,15 @@
+# escape=`
+ARG WIN_VERSION=2019
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+
+COPY otelcol-k8s.exe ./otelcol-k8s.exe
+
+ENV NO_WINDOWS_SERVICE=1
+
+ENTRYPOINT ["otelcol-k8s.exe"]
+# `4137` and `4318`: OTLP
+# `55678`: OpenCensus
+# `55679`: zpages
+# `6831`, `14268`, and `14250`: Jaeger
+# `9411`: Zipkin
+EXPOSE 4317 4318 55678 55679 6831 14268 14250 9411

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -5,6 +5,8 @@ env:
   - LD_FLAGS=-s -w
   - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+release:
+  replace_existing_artifacts: true
 msi:
   - id: otelcol-otlp
     name: otelcol-otlp_{{ .Version }}_{{ .Os }}_{{ .MsiArch }}
@@ -201,6 +203,44 @@ dockers:
       - --label=org.opencontainers.image.source={{.GitURL}}
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-windows-2019-amd64
+      - otel/opentelemetry-collector-otlp:latest-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-windows-2019-amd64
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2019
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-windows-2022-amd64
+      - otel/opentelemetry-collector-otlp:latest-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-windows-2022-amd64
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2022
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
 docker_manifests:
   - name_template: otel/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -211,6 +211,8 @@ dockers:
       - otel/opentelemetry-collector-otlp:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-windows-2019-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2019
@@ -230,6 +232,8 @@ dockers:
       - otel/opentelemetry-collector-otlp:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-windows-2022-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2022

--- a/distributions/otelcol-otlp/Windows.dockerfile
+++ b/distributions/otelcol-otlp/Windows.dockerfile
@@ -1,0 +1,10 @@
+# escape=`
+ARG WIN_VERSION=2019
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+
+COPY otelcol-otlp.exe ./otelcol-otlp.exe
+
+ENV NO_WINDOWS_SERVICE=1
+
+ENTRYPOINT ["otelcol-otlp.exe"]
+EXPOSE 4317 4318

--- a/distributions/otelcol-otlp/windows-installer.wxs
+++ b/distributions/otelcol-otlp/windows-installer.wxs
@@ -43,7 +43,7 @@
                <Component Id="ApplicationComponent" Guid="1207C3C4-1830-4DC8-8A7B-2BD7DBE45BC3">
                   <!-- Files to include -->
                   <File
-                     Id="{{ .Binary }}.exe"
+                     Id="{{ replace .Binary "-"  "_"}}.exe"
                      Name="{{ .Binary }}.exe"
                      Source="{{ .Binary }}.exe"
                      KeyPath="yes"/>

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -5,6 +5,8 @@ env:
   - LD_FLAGS=-s -w
   - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+release:
+  replace_existing_artifacts: true
 msi:
   - id: otelcol
     name: otelcol_{{ .Version }}_{{ .Os }}_{{ .MsiArch }}
@@ -217,6 +219,48 @@ dockers:
       - --label=org.opencontainers.image.source={{.GitURL}}
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector:{{ .Version }}-windows-2019-amd64
+      - otel/opentelemetry-collector:latest-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-windows-2019-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-windows-2019-amd64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2019
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
+  - goos: windows
+    goarch: amd64
+    dockerfile: Windows.dockerfile
+    image_templates:
+      - otel/opentelemetry-collector:{{ .Version }}-windows-2022-amd64
+      - otel/opentelemetry-collector:latest-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-windows-2022-amd64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-windows-2022-amd64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --build-arg=WIN_VERSION=2022
+      - --platform=windows/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: docker
 docker_manifests:
   - name_template: otel/opentelemetry-collector:{{ .Version }}
     image_templates:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -227,6 +227,8 @@ dockers:
       - otel/opentelemetry-collector:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-windows-2019-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -248,6 +250,8 @@ dockers:
       - otel/opentelemetry-collector:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-windows-2022-amd64
+    skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
+    skip_push: '{{ not (eq .Runtime.Goos "windows") }}'
     extra_files:
       - config.yaml
     build_flag_templates:

--- a/distributions/otelcol/Windows.dockerfile
+++ b/distributions/otelcol/Windows.dockerfile
@@ -1,0 +1,12 @@
+# escape=`
+ARG WIN_VERSION=2019
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+
+COPY otelcol.exe ./otelcol.exe
+COPY config.yaml ./config.yaml
+
+ENV NO_WINDOWS_SERVICE=1
+
+ENTRYPOINT ["otelcol.exe"]
+CMD ["--config", "config.yaml"]
+EXPOSE 4317 4318 55678 55679

--- a/distributions/otelcol/windows-installer.wxs
+++ b/distributions/otelcol/windows-installer.wxs
@@ -43,7 +43,7 @@
                <Component Id="ApplicationComponent" Guid="1207C3C4-1830-4DC8-8A7B-2BD7DBE45BC3">
                   <!-- Files to include -->
                   <File
-                     Id="{{ .Binary }}.exe"
+                     Id="{{ replace .Binary "-"  "_"}}.exe"
                      Name="{{ .Binary }}.exe"
                      Source="{{ .Binary }}.exe"
                      KeyPath="yes"/>


### PR DESCRIPTION
This PR adds support for releasing Windows 2019 and 2022 container images for the `amd64` architecture. 

As a reminder, [`windows/amd64` is already a supported platform (tier 2) in the Collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tier-2--secondary-support). 

Another worthy note: there are no Windows containers image produced by Microsoft on the i386 architecture. 

First of all, this was only possible after reading a lot of material about building Windows container images (https://lippertmarkus.com/2021/11/30/win-multiarch-img-lin/, https://tobiasfenster.io/building-docker-images-for-multiple-windows-server-versions-using-self-hosted-github-runners) and seeing some examples of other projects using GoReleaser that also build Windows container images (https://github.com/testcontainers/moby-ryuk/pull/52, for example). 

As byproduct of this pull request, I started [a discussion in GoReleaser to talk about my wishlist to improve support for building Windows container images with the "Split and Merge" strategy](https://github.com/orgs/goreleaser/discussions/5638). Some of the small hacks in this PR could be remove in the future as outcome of this conversation. I'll keep collaborating with the folks there to improve the support for this.

# Additional changes

- Fix slow cache restore of the `setup-go` Github Action in Windows: pretty self explanatory. The action was taking over 10 minutes to restore the cache. There are issues and PRs upstream to the action with a fix (see https://github.com/actions/setup-go/pull/515), but they weren't merged it.
- The GoReleaser `release` configuration now has `replace_existing_artifacts: true`. This is required because the split-and-merge build will try to upload some generic artifacts (like source code tarball) more than once. Without this setting on, when it tries to upload an artifact that already exists an error is returned and the build fails.
- The ID of the executable in the MSI installer template replaces dashes with underscore (`Id="{{ replace .Binary "-"  "_"}}.exe"`). This is required because now the MSI installer is built in a Windows node, which enforces that IDs contains only alphanumeric characters, dots, and underscores.

# Testing

I produced a test release in my fork using this code: https://github.com/douglascamata/opentelemetry-collector-releases/releases/tag/v0.121.0.

It contains 458 release artifacts. The upstream v0.121.0 contains 452. The new artifacts are the files for the Windows amd64 binary that now is built in the `otelcol-k8s` distro:

![image](https://github.com/user-attachments/assets/13fa7b8f-5e10-45a1-9e47-07d4fecb863a)

# Future work

## Support for `windows/arm64`

In the near feature we can add support for `windows/arm64`. I didn't add it right now for two main reasons:

- It's not a platform that is currently supported by the OpenTelemetry Collector. In fact, I tried to compile it and it didn't work because some dependencies do not compile on Windows arm64.
- Only Windows Server 2025 has arm64 images. Which means I would need to complicate this a bit more to skip arm64 for Windows 2019 and 2022.

## Windows multi-version + multi-arch images

It is possible to build a multi-version image for Windows. This means, for example, a single image manifest tagged as `otel/opentelemetry-collector-otlp:{{ .Version }}-windows-amd64` can include images for Windows 2019 and 2022.

This can be further extended by also including in the manifest images for all the architectures supported by each Windows version. We would end up with a manifest tagged like `otel/opentelemetry-collector-otlp:{{ .Version }}-windows` and potentially including support for Windows 2019, 2022, and 2025 -- including amd64 and arm64 for Windows 2025, if they will be ready then.

I didn't do this right now for two reasons:

- This PR would get bigger and it's already big enough.
- Windows containers are, so far, supported only on amd64 anyway.

This could be done in a follow up PR.

### Universal image (the dream)

It is possible to combine Windows multi-version + multi arch image with the Linux images. We would end up with a single manifest tagged as `otel/opentelemetry-collector-otlp:{{ .Version }}` that would work on all the supported Linux and Windows architectures and versions. 🤯

It's currently impossible to implement this though because of limitations in how GoReleaser handles image manifests. It currently has to load all the images going into a manifest and, as we know, Windows container image cannot be loaded on Linux and vice-versa.