### PR TITLE
fix(postinstall): ignore systemctl commands when systemd is not running

### DIFF
--- a/.chloggen/fix_linux_package_scripts.yaml
+++ b/.chloggen/fix_linux_package_scripts.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: packaging
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix Linux package scripts
+note: Ensure Linux package scripts work in environments without systemd such as chrooted environments
 
 # One or more tracking issues or pull requests related to the change
 issues: [767]

--- a/.chloggen/fix_linux_package_scripts.yaml
+++ b/.chloggen/fix_linux_package_scripts.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: packaging
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Linux package scripts
+
+# One or more tracking issues or pull requests related to the change
+issues: [767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []
+

--- a/distributions/otelcol-contrib/postinstall.sh
+++ b/distributions/otelcol-contrib/postinstall.sh
@@ -15,9 +15,13 @@
 # limitations under the License.
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl daemon-reload
+    if [ -d /run/systemd/system ]; then
+        systemctl daemon-reload
+    fi
     systemctl enable otelcol-contrib.service
     if [ -f /etc/otelcol-contrib/config.yaml ]; then
-        systemctl restart otelcol-contrib.service
+        if [ -d /run/systemd/system ]; then
+            systemctl restart otelcol-contrib.service
+        fi
     fi
 fi

--- a/distributions/otelcol-otlp/postinstall.sh
+++ b/distributions/otelcol-otlp/postinstall.sh
@@ -15,10 +15,14 @@
 # limitations under the License.
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl daemon-reload
+    if [ -d /run/systemd/system ]; then
+        systemctl daemon-reload
+    fi
     systemctl enable otelcol-otlp.service
     if [ -f /etc/otelcol-otlp/config.yaml ]; then
-        systemctl restart otelcol-otlp.service
+        if [ -d /run/systemd/system ]; then
+            systemctl restart otelcol-otlp.service
+        fi
     else
         echo "Make sure to configure otelcol-otlp by creating /etc/otelcol-otlp/config.yaml"
     fi

--- a/distributions/otelcol/postinstall.sh
+++ b/distributions/otelcol/postinstall.sh
@@ -15,9 +15,13 @@
 # limitations under the License.
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl daemon-reload
+    if [ -d /run/systemd/system ]; then
+        systemctl daemon-reload
+    fi
     systemctl enable otelcol.service
     if [ -f /etc/otelcol/config.yaml ]; then
-        systemctl restart otelcol.service
+        if [ -d /run/systemd/system ]; then
+            systemctl restart otelcol.service
+        fi
     fi
 fi


### PR DESCRIPTION
Based on #767. This avoids package manager like `dpkg` to fail in chrooted setups.