### PR TITLE
[chore] remove unneeded goreleaser hooks

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -1,5 +1,6 @@
 before:
   hooks:
+    - pwd
     - go mod download
 monorepo:
   tag_prefix: cmd/builder/

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -1,15 +1,13 @@
-before:
-  hooks:
-    - cmd: pwd
-      output: true
-    - cmd: go mod download
-      output: true
 monorepo:
   tag_prefix: cmd/builder/
   dir: .core/cmd/builder
 version: 2
 builds:
-  - flags:
+  - hooks:
+      pre:
+        - cmd: pwd
+          output: true
+    flags:
       - -trimpath
     ldflags:
       - -s -w -X go.opentelemetry.io/collector/cmd/builder/internal.version={{ .Version }}

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -1,7 +1,9 @@
 before:
   hooks:
-    - pwd
-    - go mod download
+    - cmd: pwd
+      output: true
+    - cmd: go mod download
+      output: true
 monorepo:
   tag_prefix: cmd/builder/
   dir: .core/cmd/builder

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -3,11 +3,7 @@ monorepo:
   dir: .core/cmd/builder
 version: 2
 builds:
-  - hooks:
-      pre:
-        - cmd: pwd
-          output: true
-    flags:
+  - flags:
       - -trimpath
     ldflags:
       - -s -w -X go.opentelemetry.io/collector/cmd/builder/internal.version={{ .Version }}

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -1,6 +1,3 @@
-before:
-  hooks:
-    - go mod download
 monorepo:
   tag_prefix: cmd/opampsupervisor/
   dir: .contrib/cmd/opampsupervisor


### PR DESCRIPTION
This PR fixes the first finding of the GoReleaser check workflow in the collector-core repo.
It removes unneeded build hooks from goreleaser configs that failed when running in the collector-core repo.
After looking into it, I found that they are not actually needed.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12618
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12619
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12623