### PR TITLE
Add tlscheckreceiver to otelcol-contrib

### DIFF
--- a/.chloggen/tlscheckreceiver.yaml
+++ b/.chloggen/tlscheckreceiver.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: tlscheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adding tcpcheckreceiver to otelcol-contrib
+
+# One or more tracking issues or pull requests related to the change
+issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38071]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/.chloggen/tlscheckreceiver.yaml
+++ b/.chloggen/tlscheckreceiver.yaml
@@ -10,7 +10,7 @@ component: tlscheckreceiver
 note: Adding tcpcheckreceiver to otelcol-contrib
 
 # One or more tracking issues or pull requests related to the change
-issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38071]
+issues: [880]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -200,6 +200,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver v0.122.0


### PR DESCRIPTION
This PR adds tlscheckreceiver to OpenTelemetry Collector Contrib

https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tlscheckreceiver