### PR TITLE
add loki exporter to the collector contrib distribution

### DIFF
--- a/.chloggen/add-loki-exporter.yaml
+++ b/.chloggen/add-loki-exporter.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: lokiexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the component loki exporter to the distribution
+
+# One or more tracking issues or pull requests related to the change
+issues: [892]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []
+

--- a/.chloggen/add-loki-exporter.yaml
+++ b/.chloggen/add-loki-exporter.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: new_component
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: lokiexporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Changelog
 
 <!-- next version -->
+### 💡 Enhancements 💡
+- `contrib`: Add the component loki exporter to the distribution (#892)
 
 ## v0.122.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 # Changelog
 
 <!-- next version -->
-### 💡 Enhancements 💡
-- `contrib`: Add the component loki exporter to the distribution (#892)
 
 ## v0.122.0
 

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -69,6 +69,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.122.0


### PR DESCRIPTION
The loki exporter was accidentally removed from the collector contrib distro: https://github.com/open-telemetry/opentelemetry-collector-releases/pull/854

Grafana Labs would like to keep it for a while, to support folks who are still in the process of migrating from the loki exporter to otlp exporter