### PR TITLE
feat(otelcol-contrib): add GitLab receiver module to manifest

### DIFF
--- a/.chloggen/contrib-add-gitlabreceiver.yaml
+++ b/.chloggen/contrib-add-gitlabreceiver.yaml
@@ -4,14 +4,13 @@
 change_type: new_component
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: schemaprocessor
+component: gitlabreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: |
-  Add Schema Processor to contrib
+note: Add Gitlab Receiver to contrib
 
 # One or more tracking issues or pull requests related to the change
-issues: [891]
+issues: []
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -23,5 +22,5 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user]
+change_logs: ['user']
 

--- a/.chloggen/dinesh.gurumurthy_add-schema-processor-to-contrib.yaml
+++ b/.chloggen/dinesh.gurumurthy_add-schema-processor-to-contrib.yaml
@@ -4,14 +4,14 @@
 change_type: new_component
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: schemaprocessor
+component: gitlabreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: |
-  Add Schema Processor to contrib
+  Add Gitlab Receiver to contrib
 
 # One or more tracking issues or pull requests related to the change
-issues: [891]
+issues: []
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -23,5 +23,5 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user]
+change_logs: []
 

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -213,6 +213,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver v0.122.0
 
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.122.1


### PR DESCRIPTION
I'm not entirely sure about this modification. It's just that when I was using the GitLab receiver, I noticed it was missing this component. So I tried to find it here.