### PR TITLE
Remove dockerhub destination

### DIFF
--- a/.chloggen/tyler.remove-dockerhub-destination.yaml
+++ b/.chloggen/tyler.remove-dockerhub-destination.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: image repository
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Due to the new Dockerhub rate limits we are no longer publishing images to dockerhub.
+
+# One or more tracking issues or pull requests related to the change
+issues: [902]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: If we can solve the rate limiting issue we'll undo this change
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []
+

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -30,8 +30,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-builder:latest-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-amd64
     build_flag_templates:
@@ -47,8 +45,6 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-builder:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-arm64
     build_flag_templates:
@@ -64,8 +60,6 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-builder:latest-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-ppc64le
     build_flag_templates:
@@ -79,16 +73,6 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-builder:{{ .Version }}
-    image_templates:
-      - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
-  - name_template: otel/opentelemetry-collector-builder:latest
-    image_templates:
-      - otel/opentelemetry-collector-builder:latest-amd64
-      - otel/opentelemetry-collector-builder:latest-arm64
-      - otel/opentelemetry-collector-builder:latest-ppc64le
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -34,7 +34,6 @@ const (
 	contribDistro    = "otelcol-contrib"
 	k8sDistro        = "otelcol-k8s"
 	otlpDistro       = "otelcol-otlp"
-	dockerHub        = "otel"
 	ghcr             = "ghcr.io/open-telemetry/opentelemetry-collector-releases"
 	binaryNamePrefix = "otelcol"
 	imageNamePrefix  = "opentelemetry-collector"
@@ -47,7 +46,7 @@ var (
 	darwinArchs       = []string{"amd64", "arm64"}
 	k8sArchs          = []string{"amd64", "arm64", "ppc64le", "s390x"}
 
-	imageRepos = []string{dockerHub, ghcr}
+	imageRepos = []string{ghcr}
 
 	// otelcol (core) distro
 	otelColDist = newDistributionBuilder(coreDistro).WithConfigFunc(func(d *distribution) {

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -30,8 +30,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-opampsupervisor:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-opampsupervisor:latest-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-amd64
     build_flag_templates:
@@ -47,8 +45,6 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-opampsupervisor:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-opampsupervisor:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-arm64
     build_flag_templates:
@@ -64,8 +60,6 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-opampsupervisor:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-opampsupervisor:latest-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Version }}-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:latest-ppc64le
     build_flag_templates:
@@ -79,16 +73,6 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-opampsupervisor:{{ .Version }}
-    image_templates:
-      - otel/opentelemetry-collector-opampsupervisor:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-opampsupervisor:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-opampsupervisor:{{ .Version }}-ppc64le
-  - name_template: otel/opentelemetry-collector-opampsupervisor:latest
-    image_templates:
-      - otel/opentelemetry-collector-opampsupervisor:latest-amd64
-      - otel/opentelemetry-collector-opampsupervisor:latest-arm64
-      - otel/opentelemetry-collector-opampsupervisor:latest-ppc64le
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Version }}-amd64

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -107,8 +107,6 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
-      - otel/opentelemetry-collector-contrib:latest-386
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-386
     extra_files:
@@ -127,8 +125,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-contrib:latest-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-amd64
     extra_files:
@@ -148,8 +144,6 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-contrib:latest-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-armv7
     extra_files:
@@ -168,8 +162,6 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-contrib:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-arm64
     extra_files:
@@ -188,8 +180,6 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-contrib:latest-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-ppc64le
     extra_files:
@@ -208,8 +198,6 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
-      - otel/opentelemetry-collector-contrib:latest-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-s390x
     extra_files:
@@ -228,8 +216,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-windows-2019-amd64
-      - otel/opentelemetry-collector-contrib:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-windows-2019-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -251,8 +237,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-windows-2022-amd64
-      - otel/opentelemetry-collector-contrib:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-windows-2022-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -271,22 +255,6 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: docker
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-contrib:{{ .Version }}
-    image_templates:
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-386
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector-contrib:latest
-    image_templates:
-      - otel/opentelemetry-collector-contrib:latest-386
-      - otel/opentelemetry-collector-contrib:latest-amd64
-      - otel/opentelemetry-collector-contrib:latest-armv7
-      - otel/opentelemetry-collector-contrib:latest-arm64
-      - otel/opentelemetry-collector-contrib:latest-ppc64le
-      - otel/opentelemetry-collector-contrib:latest-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-386

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -48,8 +48,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-k8s:latest-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-amd64
     build_flag_templates:
@@ -66,8 +64,6 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-k8s:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-arm64
     build_flag_templates:
@@ -84,8 +80,6 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-k8s:latest-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-ppc64le
     build_flag_templates:
@@ -102,8 +96,6 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
-      - otel/opentelemetry-collector-k8s:latest-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-s390x
     build_flag_templates:
@@ -120,8 +112,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-windows-2019-amd64
-      - otel/opentelemetry-collector-k8s:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-windows-2019-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -141,8 +131,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-windows-2022-amd64
-      - otel/opentelemetry-collector-k8s:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-windows-2022-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -159,18 +147,6 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: docker
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-k8s:{{ .Version }}
-    image_templates:
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector-k8s:latest
-    image_templates:
-      - otel/opentelemetry-collector-k8s:latest-amd64
-      - otel/opentelemetry-collector-k8s:latest-arm64
-      - otel/opentelemetry-collector-k8s:latest-ppc64le
-      - otel/opentelemetry-collector-k8s:latest-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -98,8 +98,6 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
-      - otel/opentelemetry-collector-otlp:latest-386
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-386
     build_flag_templates:
@@ -116,8 +114,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-otlp:latest-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-amd64
     build_flag_templates:
@@ -135,8 +131,6 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-otlp:latest-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-armv7
     build_flag_templates:
@@ -153,8 +147,6 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-otlp:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-arm64
     build_flag_templates:
@@ -171,8 +163,6 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-otlp:latest-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-ppc64le
     build_flag_templates:
@@ -189,8 +179,6 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
-      - otel/opentelemetry-collector-otlp:latest-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-s390x
     build_flag_templates:
@@ -207,8 +195,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-windows-2019-amd64
-      - otel/opentelemetry-collector-otlp:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-windows-2019-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -228,8 +214,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-windows-2022-amd64
-      - otel/opentelemetry-collector-otlp:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-windows-2022-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -246,22 +230,6 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: docker
 docker_manifests:
-  - name_template: otel/opentelemetry-collector-otlp:{{ .Version }}
-    image_templates:
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-386
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-amd64
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector-otlp:latest
-    image_templates:
-      - otel/opentelemetry-collector-otlp:latest-386
-      - otel/opentelemetry-collector-otlp:latest-amd64
-      - otel/opentelemetry-collector-otlp:latest-armv7
-      - otel/opentelemetry-collector-otlp:latest-arm64
-      - otel/opentelemetry-collector-otlp:latest-ppc64le
-      - otel/opentelemetry-collector-otlp:latest-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-386

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -102,8 +102,6 @@ dockers:
     goarch: "386"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-386
-      - otel/opentelemetry-collector:latest-386
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-386
     extra_files:
@@ -122,8 +120,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-amd64
-      - otel/opentelemetry-collector:latest-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-amd64
     extra_files:
@@ -143,8 +139,6 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-armv7
-      - otel/opentelemetry-collector:latest-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-armv7
     extra_files:
@@ -163,8 +157,6 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-arm64
-      - otel/opentelemetry-collector:latest-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-arm64
     extra_files:
@@ -183,8 +175,6 @@ dockers:
     goarch: ppc64le
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector:latest-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-ppc64le
     extra_files:
@@ -203,8 +193,6 @@ dockers:
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-s390x
-      - otel/opentelemetry-collector:latest-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-s390x
     extra_files:
@@ -223,8 +211,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-windows-2019-amd64
-      - otel/opentelemetry-collector:latest-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-windows-2019-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-windows-2019-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -246,8 +232,6 @@ dockers:
     goarch: amd64
     dockerfile: Windows.dockerfile
     image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-windows-2022-amd64
-      - otel/opentelemetry-collector:latest-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-windows-2022-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-windows-2022-amd64
     skip_build: '{{ not (eq .Runtime.Goos "windows") }}'
@@ -266,22 +250,6 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: docker
 docker_manifests:
-  - name_template: otel/opentelemetry-collector:{{ .Version }}
-    image_templates:
-      - otel/opentelemetry-collector:{{ .Version }}-386
-      - otel/opentelemetry-collector:{{ .Version }}-amd64
-      - otel/opentelemetry-collector:{{ .Version }}-armv7
-      - otel/opentelemetry-collector:{{ .Version }}-arm64
-      - otel/opentelemetry-collector:{{ .Version }}-ppc64le
-      - otel/opentelemetry-collector:{{ .Version }}-s390x
-  - name_template: otel/opentelemetry-collector:latest
-    image_templates:
-      - otel/opentelemetry-collector:latest-386
-      - otel/opentelemetry-collector:latest-amd64
-      - otel/opentelemetry-collector:latest-armv7
-      - otel/opentelemetry-collector:latest-arm64
-      - otel/opentelemetry-collector:latest-ppc64le
-      - otel/opentelemetry-collector:latest-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-386


### PR DESCRIPTION
Dockerhub has new rate limits that broke our release process.

While others figure out how to increase our rate we're going to stop publishing images to dockerhub.

Related issue: https://github.com/open-telemetry/community/issues/2641