### PR TITLE
Add option to allow enabling cgo in distributions

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -384,6 +384,7 @@ type distribution struct {
 	dockerSigns             []config.Sign
 	sboms                   []config.SBOM
 	checksum                config.Checksum
+	enableCgo               bool
 }
 
 func (d *distribution) BuildProject() config.Project {
@@ -392,18 +393,22 @@ func (d *distribution) BuildProject() config.Project {
 		builds = append(builds, buildConfig.Build(d.name))
 	}
 
+	env := []string{
+		"COSIGN_YES=true",
+		"LD_FLAGS=-s -w",
+		"BUILD_FLAGS=-trimpath",
+	}
+	if !d.enableCgo {
+		env = append(env, "CGO_ENABLED=0")
+	}
+
 	return config.Project{
 		ProjectName: "opentelemetry-collector-releases",
 		Release: config.Release{
 			ReplaceExistingArtifacts: true,
 		},
-		Checksum: d.checksum,
-		Env: []string{
-			"COSIGN_YES=true",
-			"LD_FLAGS=-s -w",
-			"CGO_ENABLED=0",
-			"BUILD_FLAGS=-trimpath",
-		},
+		Checksum:        d.checksum,
+		Env:             env,
 		Builds:          builds,
 		Archives:        d.archives,
 		MSI:             d.msiConfig,

--- a/distributions/otelcol-contrib/.goreleaser-build.yaml
+++ b/distributions/otelcol-contrib/.goreleaser-build.yaml
@@ -3,8 +3,8 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+  - CGO_ENABLED=0
 release:
   replace_existing_artifacts: true
 builds:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -3,8 +3,8 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+  - CGO_ENABLED=0
 release:
   replace_existing_artifacts: true
 msi:

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -3,8 +3,8 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+  - CGO_ENABLED=0
 release:
   replace_existing_artifacts: true
 builds:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -3,8 +3,8 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+  - CGO_ENABLED=0
 release:
   replace_existing_artifacts: true
 msi:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -3,8 +3,8 @@ project_name: opentelemetry-collector-releases
 env:
   - COSIGN_YES=true
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
   - BUILD_FLAGS=-trimpath
+  - CGO_ENABLED=0
 release:
   replace_existing_artifacts: true
 msi:


### PR DESCRIPTION
This will be needed by the eBPF profiler distributions.