### PR TITLE
Add support for custom ldtags and go tags

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -385,6 +385,8 @@ type distribution struct {
 	sboms                   []config.SBOM
 	checksum                config.Checksum
 	enableCgo               bool
+	ldFlags                 string
+	goTags                  string
 }
 
 func (d *distribution) BuildProject() config.Project {
@@ -393,10 +395,18 @@ func (d *distribution) BuildProject() config.Project {
 		builds = append(builds, buildConfig.Build(d.name))
 	}
 
+	ldFlags := "-s -w"
+	if d.ldFlags != "" {
+		ldFlags = d.ldFlags
+	}
+
 	env := []string{
 		"COSIGN_YES=true",
-		"LD_FLAGS=-s -w",
+		"LD_FLAGS=" + ldFlags,
 		"BUILD_FLAGS=-trimpath",
+	}
+	if d.goTags != "" {
+		env = append(env, "GO_TAGS="+d.goTags)
 	}
 	if !d.enableCgo {
 		env = append(env, "CGO_ENABLED=0")


### PR DESCRIPTION
So the eBPF profiler can use custom ld tags, as well as Go tags.

See https://github.com/open-telemetry/opentelemetry-collector-releases/pull/908#discussion_r2041460234