### PR TITLE
add breaking change note for 0.121.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
 
 ## v0.121.0
 
+### 🛑 Breaking changes 🛑
+
+- container group ID: Set user's primary group (USER_GID) to prevent container user 10001 being root group. (#738)
+
 ### 🚀 New components 🚀
 
 - `aesprovider`: Add the AES provider to the contrib distribution (#843)


### PR DESCRIPTION
During 0.121.0 release, we modified the container's user group permissions, which broke some current deployments that were relying on those permissions.

Context: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39149#issuecomment-2800986614