### PR TITLE
Add azureauthextension to contrib distribution

### DIFF
--- a/.chloggen/add-azureauthextension.yaml
+++ b/.chloggen/add-azureauthextension.yaml
@@ -22,5 +22,5 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]
 

--- a/.chloggen/add-azureauthextension.yaml
+++ b/.chloggen/add-azureauthextension.yaml
@@ -10,7 +10,7 @@ component: azureauthextension
 note: Add azureauthextension to contrib distribution.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [931]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/add-azureauthextension.yaml
+++ b/.chloggen/add-azureauthextension.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: azureauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add azureauthextension to contrib distribution.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []
+

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -10,6 +10,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.124.1


### PR DESCRIPTION
Adds azure auth extension to the contrib distribution after stability was [updated to alpha](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39574).