### PR TITLE
[chore] Enable ebpf-profiler digest upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,13 @@
     },
     {
       "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["go.opentelemetry.io/ebpf-profiler"],
+      "matchUpdateTypes": ["digest"],
+      "groupName": "eBPF Profiler",
+      "enabled": true
+    },
+    {
+      "matchManagers": ["gomod"],
       "matchDepTypes": ["toolchain"],
       "enabled": false
     },


### PR DESCRIPTION
So ebpf-profiler is updated weekly with its latest digest.
As discussed in https://github.com/open-telemetry/opentelemetry-collector-releases/pull/933#discussion_r2064828143