### PR TITLE
Release the eBPF Profiler image

### DIFF
--- a/.chloggen/release-ebpf-profiler.yaml
+++ b/.chloggen/release-ebpf-profiler.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: ebpf-profiler
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Build releases of the eBPF profiler distribution
+
+# One or more tracking issues or pull requests related to the change
+issues: [958]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.github/workflows/release-ebpf-profiler.yaml
+++ b/.github/workflows/release-ebpf-profiler.yaml
@@ -1,0 +1,16 @@
+name: Release eBPF Profiler
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release:
+    name: Release ebPF Profiler
+    uses: ./.github/workflows/base-release.yaml
+    with:
+      distribution: otelcol-ebpf-profiler
+      goos: '[ "linux" ]'
+      goarch: '[ "amd64" ]'
+    secrets: inherit
+    permissions: write-all


### PR DESCRIPTION
We introduced the eBPF Profiler distribution in https://github.com/open-telemetry/opentelemetry-collector-releases/pull/908.
In order to avoid unforeseen issues, we haven't been publishing the image yet.
This change has been shipped for a few weeks now. So this adds the distribution's release.