### PR TITLE
Revert "[chore] add default permissions block to workflows"

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -1,8 +1,5 @@
 name: Reusable GoReleaser CI workflow
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -67,7 +64,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -268,8 +264,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/base-package-tests.yaml
+++ b/.github/workflows/base-package-tests.yaml
@@ -1,8 +1,5 @@
 name: Package Tests
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -28,8 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
 
       - name: Download built artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -1,8 +1,5 @@
 name: Reusable release workflow
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -45,7 +42,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
@@ -158,7 +154,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -1,8 +1,4 @@
 name: Release Builder
-
-permissions:
-  contents: read
-
 on:
   push:
     tags:
@@ -26,7 +22,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Push cmd/builder Tag
         run: |
           tag="cmd/builder/${{ github.ref_name }}"
@@ -42,7 +37,6 @@ jobs:
           repository: "open-telemetry/opentelemetry-collector"
           ref: ${{ github.ref_name }}
           path: ".core"
-          persist-credentials: false
       - name: Copy Dockerfile to Core Repo directory
         run:  cp cmd/builder/Dockerfile .core/cmd/builder/Dockerfile
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2

--- a/.github/workflows/builder-testbuild.yaml
+++ b/.github/workflows/builder-testbuild.yaml
@@ -1,8 +1,5 @@
 name: CI - Builder
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:
@@ -38,14 +35,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Checkout Core Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: "open-telemetry/opentelemetry-collector"
           path: ".core"
-          persist-credentials: false
       - name: Copy Dockerfile to Core Repo directory
         run:  cp cmd/builder/Dockerfile .core/cmd/builder/Dockerfile
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,9 +5,6 @@
 
 name: Changelog
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -31,11 +28,10 @@ jobs:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@v5
         with:
           go-version: "~1.24"
           cache: false

--- a/.github/workflows/ci-goreleaser-contrib.yaml
+++ b/.github/workflows/ci-goreleaser-contrib.yaml
@@ -1,8 +1,5 @@
 name: CI - Contrib - GoReleaser
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:

--- a/.github/workflows/ci-goreleaser-core.yaml
+++ b/.github/workflows/ci-goreleaser-core.yaml
@@ -1,8 +1,5 @@
 name: CI - Core - GoReleaser
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:

--- a/.github/workflows/ci-goreleaser-ebpf-profiler.yaml
+++ b/.github/workflows/ci-goreleaser-ebpf-profiler.yaml
@@ -1,8 +1,5 @@
 name: CI - eBPF Profiler - GoReleaser
 
-permissions:
-  contents: read
-
 on:
   merge_group:
   push:

--- a/.github/workflows/ci-goreleaser-k8s.yaml
+++ b/.github/workflows/ci-goreleaser-k8s.yaml
@@ -1,8 +1,5 @@
 name: CI - k8s - GoReleaser
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:

--- a/.github/workflows/ci-goreleaser-otlp.yaml
+++ b/.github/workflows/ci-goreleaser-otlp.yaml
@@ -1,8 +1,5 @@
 name: CI - OTLP - GoReleaser
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: CI - Binaries
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:
@@ -19,7 +16,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
 
       - uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7.0
         with:

--- a/.github/workflows/msi-tests.yaml
+++ b/.github/workflows/msi-tests.yaml
@@ -1,8 +1,5 @@
 name: MSI Tests
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -23,8 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
 
       - name: Download built artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/opampsupervisor-release.yaml
+++ b/.github/workflows/opampsupervisor-release.yaml
@@ -1,8 +1,4 @@
 name: Release OpAMP supervisor
-
-permissions:
-  contents: read
-
 on:
   push:
     tags:
@@ -26,7 +22,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Push cmd/opampsupervisor Tag
         run: |
           tag="cmd/opampsupervisor/${{ github.ref_name }}"
@@ -42,7 +37,6 @@ jobs:
           repository: "open-telemetry/opentelemetry-collector-contrib"
           ref: ${{ github.ref_name }}
           path: ".contrib"
-          persist-credentials: false
       - name: Copy Dockerfile to Contrib Repo directory
         run:  cp cmd/opampsupervisor/Dockerfile .contrib/cmd/opampsupervisor/Dockerfile
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2

--- a/.github/workflows/opampsupervisor-testbuild.yaml
+++ b/.github/workflows/opampsupervisor-testbuild.yaml
@@ -1,8 +1,5 @@
 name: CI - OpAMP supervisor
 
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:
@@ -36,14 +33,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Checkout Core Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: "open-telemetry/opentelemetry-collector-contrib"
           path: ".contrib"
-          persist-credentials: false
       - name: Copy Dockerfile to Core Repo directory
         run:  cp cmd/opampsupervisor/Dockerfile .contrib/cmd/opampsupervisor/Dockerfile
       - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2

--- a/.github/workflows/package-test.yaml
+++ b/.github/workflows/package-test.yaml
@@ -1,8 +1,5 @@
 name: Package Tests - Contrib
 
-permissions:
-  contents: read
-
 on:
   schedule:
     - cron: "0 2 * * *" # every day at 2am UTC

--- a/.github/workflows/release-contrib.yaml
+++ b/.github/workflows/release-contrib.yaml
@@ -1,8 +1,5 @@
 name: Release Contrib
 
-permissions:
-  contents: read
-
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release-core.yaml
+++ b/.github/workflows/release-core.yaml
@@ -1,8 +1,5 @@
 name: Release Core
 
-permissions:
-  contents: read
-
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release-ebpf-profiler.yaml
+++ b/.github/workflows/release-ebpf-profiler.yaml
@@ -1,8 +1,5 @@
 name: Release eBPF Profiler
 
-permissions:
-  contents: read
-
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release-k8s.yaml
+++ b/.github/workflows/release-k8s.yaml
@@ -1,8 +1,5 @@
 name: Release k8s
 
-permissions:
-  contents: read
-
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release-otlp.yaml
+++ b/.github/workflows/release-otlp.yaml
@@ -1,8 +1,5 @@
 name: Release OTLP
 
-permissions:
-  contents: read
-
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,8 +1,4 @@
 name: Shellcheck lint
-
-permissions:
-  contents: read
-
 on:
   merge_group: 
   push:
@@ -16,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         env:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,4 @@
 name: "Close stale issues and pull requests"
-
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,8 +1,4 @@
 name: Update Version in Distributions and Prepare PR
-
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
     inputs:
@@ -27,8 +23,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
 
       - name: Run bump-versions.sh
         run: |


### PR DESCRIPTION
Seeing what appear to be permission related failures during the release process (https://github.com/open-telemetry/opentelemetry-collector-releases/issues/965 & #962), rolling this change back to see if it fixes the issues. Reverts open-telemetry/opentelemetry-collector-releases#959