### PR TITLE
Add riscv64 arch

### DIFF
--- a/.chloggen/rv64.yaml
+++ b/.chloggen/rv64.yaml
@@ -7,7 +7,7 @@ change_type: 'enhancement'
 component: platforms
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: New Tier 3 - riscv64
+note: Add Tier 3 support for riscv64
 
 
 # One or more tracking issues or pull requests related to the change

--- a/.chloggen/rv64.yaml
+++ b/.chloggen/rv64.yaml
@@ -7,7 +7,7 @@ change_type: 'enhancement'
 component: platforms
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: New platform support - riscv64
+note: New Tier 3 - riscv64
 
 
 # One or more tracking issues or pull requests related to the change
@@ -17,7 +17,7 @@ issues: [968, 969]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  New platform support: riscv64 architecture is now included,
+  New Tier 3 platform: riscv64 architecture is now included,
   allowing the collector to be built and distributed for this platform.
 
 # Optional: The change log or logs in which this entry should be included.

--- a/.chloggen/rv64.yaml
+++ b/.chloggen/rv64.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: platforms
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: New platform support - riscv64
+
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  New platform support: riscv64 architecture is now included,
+  allowing the collector to be built and distributed for this platform.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/.chloggen/rv64.yaml
+++ b/.chloggen/rv64.yaml
@@ -11,7 +11,7 @@ note: New platform support - riscv64
 
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [968, 969]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -55,6 +55,10 @@ jobs:
             GOARCH: ppc64le
           - GOOS: windows
             GOARCH: ppc64le
+          - GOOS: darwin
+            GOARCH: riscv64
+          - GOOS: windows
+            GOARCH: riscv64
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.prep.outputs.version }}
@@ -68,7 +72,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm64,ppc64le,linux/arm/v7,s390x
+          platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
 
       - name: Setup wixl # Required to build MSI packages for Windows
         if: ${{ matrix.GOOS == 'windows' && ( matrix.GOARCH == '386' || matrix.GOARCH == 'amd64') }}
@@ -268,7 +272,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm64,ppc64le,linux/arm/v7,s390x
+          platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
 
       - name: Download container image artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -42,6 +42,8 @@ jobs:
             GOARCH: ppc64le
           - GOOS: darwin
             GOARCH: arm
+          - GOOS: darwin
+            GOARCH: riscv64
     runs-on: ${{ inputs.runner_os }}
     permissions:
       packages: write

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: runner.os != 'Windows'
         with:
-          platforms: arm64,ppc64le,linux/arm/v7,s390x
+          platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         if: runner.os != 'Windows'
@@ -188,7 +188,7 @@ jobs:
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: runner.os != 'Windows'
         with:
-          platforms: arm64,ppc64le,s390x
+          platforms: arm64,ppc64le,s390x,riscv64
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         if: runner.os != 'Windows'

--- a/.github/workflows/ci-builder.yaml
+++ b/.github/workflows/ci-builder.yaml
@@ -1,7 +1,7 @@
 name: CI - Builder
 
 on:
-  merge_group: 
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -47,7 +47,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: amd64, arm64,ppc64le
+          platforms: amd64,arm64,ppc64le,riscv64
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/ci-goreleaser-contrib.yaml
+++ b/.github/workflows/ci-goreleaser-contrib.yaml
@@ -1,7 +1,7 @@
 name: CI - Contrib - GoReleaser
 
 on:
-  merge_group: 
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -30,7 +30,7 @@ jobs:
     with:
       distribution: otelcol-contrib
       goos: '[ "linux", "windows", "darwin" ]'
-      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+      goarch: '[ "386", "amd64", "arm", "arm64", "ppc64le", "riscv64", "s390x" ]'
     secrets: inherit
 
   package-tests:

--- a/.github/workflows/ci-goreleaser-core.yaml
+++ b/.github/workflows/ci-goreleaser-core.yaml
@@ -30,7 +30,7 @@ jobs:
     with:
       distribution: otelcol
       goos: '[ "linux", "windows", "darwin" ]'
-      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+      goarch: '[ "386", "amd64", "arm", "arm64", "ppc64le", "riscv64", "s390x" ]'
     secrets: inherit
 
   package-tests:

--- a/.github/workflows/ci-goreleaser-k8s.yaml
+++ b/.github/workflows/ci-goreleaser-k8s.yaml
@@ -1,7 +1,7 @@
 name: CI - k8s - GoReleaser
 
 on:
-  merge_group: 
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -30,5 +30,5 @@ jobs:
     with:
       distribution: otelcol-k8s
       goos: '[ "linux" ]'
-      goarch: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
+      goarch: '[ "amd64", "arm64", "ppc64le", "riscv64", "s390x" ]'
     secrets: inherit

--- a/.github/workflows/ci-goreleaser-otlp.yaml
+++ b/.github/workflows/ci-goreleaser-otlp.yaml
@@ -1,7 +1,7 @@
 name: CI - OTLP - GoReleaser
 
 on:
-  merge_group: 
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -30,5 +30,5 @@ jobs:
     with:
       distribution: otelcol-otlp
       goos: '[ "linux", "windows", "darwin" ]'
-      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+      goarch: '[ "386", "amd64", "arm", "arm64", "ppc64le", "riscv64", "s390x" ]'
     secrets: inherit

--- a/.github/workflows/ci-opampsupervisor.yaml
+++ b/.github/workflows/ci-opampsupervisor.yaml
@@ -1,7 +1,7 @@
 name: CI - OpAMP supervisor
 
 on:
-  merge_group: 
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -45,7 +45,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: amd64, arm64,ppc64le
+          platforms: amd64,arm64,ppc64le,riscv64
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/ci-opampsupervisor.yaml
+++ b/.github/workflows/ci-opampsupervisor.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: amd64,arm64,ppc64le,riscv64
+          platforms: amd64,arm64,ppc64le
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/release-builder.yaml
+++ b/.github/workflows/release-builder.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    
+
     permissions:
       id-token: write
       packages: write
@@ -71,7 +71,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: amd64, arm64,ppc64le
+          platforms: amd64,arm64,ppc64le,riscv64
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/release-contrib.yaml
+++ b/.github/workflows/release-contrib.yaml
@@ -11,7 +11,7 @@ jobs:
     with:
       distribution: otelcol-contrib
       goos: '[ "linux", "darwin" ]'
-      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x", "riscv64" ]'
       nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-core.yaml
+++ b/.github/workflows/release-core.yaml
@@ -11,7 +11,7 @@ jobs:
     with:
       distribution: otelcol
       goos: '[ "linux", "darwin" ]'
-      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x", "riscv64" ]'
       nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-opampsupervisor.yaml
+++ b/.github/workflows/release-opampsupervisor.yaml
@@ -71,7 +71,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: amd64,arm64,ppc64le,riscv64
+          platforms: amd64,arm64,ppc64le
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/release-opampsupervisor.yaml
+++ b/.github/workflows/release-opampsupervisor.yaml
@@ -71,7 +71,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: amd64, arm64,ppc64le
+          platforms: amd64,arm64,ppc64le,riscv64
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/release-otlp.yaml
+++ b/.github/workflows/release-otlp.yaml
@@ -11,7 +11,7 @@ jobs:
     with:
       distribution: otelcol-otlp
       goos: '[ "linux", "darwin" ]'
-      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x" ]'
+      goarch: '[ "386", "amd64", "arm64", "ppc64le", "arm", "s390x", "riscv64" ]'
       nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ make goreleaser-verify
 
 ## Building Multi-Architecture Docker Images
 
-`goreleaser` will build Docker images for various architectures, including `x86_64`, `386`, `arm`, `arm64`, and `ppc64le`. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
+`goreleaser` will build Docker images for various architectures, including `x86_64`, `386`, `arm`, `arm64`, `ppc64le`, and `riscv64`. The build process involves executing `RUN` steps on the target architecture, which means the system you run it on needs support for emulating foreign architectures.
 
 To set up the environment for building multi-architecture images:
 

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       - amd64
       - arm64
       - ppc64le
+      - riscv64
     ignore:
       - goos: windows
         goarch: arm64
@@ -26,6 +27,10 @@ builds:
         goarch: ppc64le
       - goos: darwin
         goarch: ppc64le
+      - goos: windows
+        goarch: riscv64
+      - goos: darwin
+        goarch: riscv64
     binary: ocb
 dockers:
   - goos: linux

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -90,9 +90,9 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - otel/opentelemetry-collector-builder:{{ .Version }}-riscv64
-      - otel/opentelemetry-collector-builder:latest-riscv64
+      - otel/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-riscv64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
     build_flag_templates:
       - --pull
       - --platform=linux/riscv64

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -85,27 +85,49 @@ dockers:
       - --label=org.opencontainers.image.source={{.GitURL}}
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
+  - goos: linux
+    goarch: riscv64
+    dockerfile: Dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-builder:{{ .Version }}-riscv64
+      - otel/opentelemetry-collector-builder:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:latest-riscv64
+    build_flag_templates:
+      - --pull
+      - --platform=linux/riscv64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
 docker_manifests:
   - name_template: otel/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
       - otel/opentelemetry-collector-builder:{{ .Version }}-amd64
       - otel/opentelemetry-collector-builder:{{ .Version }}-arm64
       - otel/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-builder:{{ .Version }}-riscv64
   - name_template: otel/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
       - otel/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-amd64
       - otel/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - otel/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - otel/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Version }}-riscv64
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
 release:
   make_latest: false
   github:

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -42,11 +42,11 @@ const (
 )
 
 var (
-	baseArchs         = []string{"386", "amd64", "arm", "arm64", "ppc64le", "s390x"}
+	baseArchs         = []string{"386", "amd64", "arm", "arm64", "ppc64le", "riscv64", "s390x"}
 	winArchs          = []string{"386", "amd64", "arm64"}
 	winContainerArchs = []string{"amd64"}
 	darwinArchs       = []string{"amd64", "arm64"}
-	k8sArchs          = []string{"amd64", "arm64", "ppc64le", "s390x"}
+	k8sArchs          = []string{"amd64", "arm64", "ppc64le", "riscv64", "s390x"}
 	ebpfProfilerArchs = []string{"amd64"}
 
 	imageRepos = []string{dockerHub, ghcr}

--- a/distributions/otelcol-contrib/.goreleaser-build.yaml
+++ b/distributions/otelcol-contrib/.goreleaser-build.yaml
@@ -18,6 +18,7 @@ builds:
       - arm
       - arm64
       - ppc64le
+      - riscv64
       - s390x
     goarm:
       - "7"

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -211,9 +211,9 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - otel/opentelemetry-collector-contrib:{{ .Version }}-riscv64
-      - otel/opentelemetry-collector-contrib:latest-riscv64
+      - otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-riscv64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
     extra_files:
       - config.yaml
     build_flag_templates:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - arm
       - arm64
       - ppc64le
+      - riscv64
       - s390x
     goarm:
       - "7"
@@ -206,6 +207,26 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
   - goos: linux
+    goarch: riscv64
+    dockerfile: Dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-riscv64
+      - otel/opentelemetry-collector-contrib:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest-riscv64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/riscv64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
@@ -279,6 +300,7 @@ docker_manifests:
       - otel/opentelemetry-collector-contrib:{{ .Version }}-armv7
       - otel/opentelemetry-collector-contrib:{{ .Version }}-arm64
       - otel/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-contrib:{{ .Version }}-riscv64
       - otel/opentelemetry-collector-contrib:{{ .Version }}-s390x
   - name_template: otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
@@ -287,6 +309,7 @@ docker_manifests:
       - otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-armv7
       - otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - otel/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}
     image_templates:
@@ -295,6 +318,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Version }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
@@ -303,6 +327,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
 signs:
   - cmd: cosign

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -105,9 +105,9 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - otel/opentelemetry-collector-k8s:{{ .Version }}-riscv64
-      - otel/opentelemetry-collector-k8s:latest-riscv64
+      - otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-riscv64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
     build_flag_templates:
       - --pull
       - --platform=linux/riscv64

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
       - amd64
       - arm64
       - ppc64le
+      - riscv64
       - s390x
     goppc64:
       - power8
@@ -100,6 +101,24 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
   - goos: linux
+    goarch: riscv64
+    dockerfile: Dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-riscv64
+      - otel/opentelemetry-collector-k8s:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest-riscv64
+    build_flag_templates:
+      - --pull
+      - --platform=linux/riscv64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
@@ -165,24 +184,28 @@ docker_manifests:
       - otel/opentelemetry-collector-k8s:{{ .Version }}-amd64
       - otel/opentelemetry-collector-k8s:{{ .Version }}-arm64
       - otel/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-k8s:{{ .Version }}-riscv64
       - otel/opentelemetry-collector-k8s:{{ .Version }}-s390x
   - name_template: otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
       - otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-amd64
       - otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - otel/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Version }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-amd64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
 signs:
   - cmd: cosign

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -24,6 +24,7 @@ builds:
       - arm
       - arm64
       - ppc64le
+      - riscv64
       - s390x
     goarm:
       - "7"
@@ -187,6 +188,24 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
   - goos: linux
+    goarch: riscv64
+    dockerfile: Dockerfile
+    image_templates:
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-riscv64
+      - otel/opentelemetry-collector-otlp:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-riscv64
+    build_flag_templates:
+      - --pull
+      - --platform=linux/riscv64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
@@ -254,6 +273,7 @@ docker_manifests:
       - otel/opentelemetry-collector-otlp:{{ .Version }}-armv7
       - otel/opentelemetry-collector-otlp:{{ .Version }}-arm64
       - otel/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector-otlp:{{ .Version }}-riscv64
       - otel/opentelemetry-collector-otlp:{{ .Version }}-s390x
   - name_template: otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
@@ -262,6 +282,7 @@ docker_manifests:
       - otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-armv7
       - otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}
     image_templates:
@@ -270,6 +291,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
@@ -278,6 +300,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
 signs:
   - cmd: cosign

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -192,9 +192,9 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - otel/opentelemetry-collector-otlp:{{ .Version }}-riscv64
-      - otel/opentelemetry-collector-otlp:latest-riscv64
+      - otel/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Version }}-riscv64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
     build_flag_templates:
       - --pull
       - --platform=linux/riscv64

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - arm
       - arm64
       - ppc64le
+      - riscv64
       - s390x
     goarm:
       - "7"
@@ -201,6 +202,26 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
   - goos: linux
+    goarch: riscv64
+    dockerfile: Dockerfile
+    image_templates:
+      - otel/opentelemetry-collector:{{ .Version }}-riscv64
+      - otel/opentelemetry-collector:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-riscv64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/riscv64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
     goarch: s390x
     dockerfile: Dockerfile
     image_templates:
@@ -274,6 +295,7 @@ docker_manifests:
       - otel/opentelemetry-collector:{{ .Version }}-armv7
       - otel/opentelemetry-collector:{{ .Version }}-arm64
       - otel/opentelemetry-collector:{{ .Version }}-ppc64le
+      - otel/opentelemetry-collector:{{ .Version }}-riscv64
       - otel/opentelemetry-collector:{{ .Version }}-s390x
   - name_template: otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
@@ -282,6 +304,7 @@ docker_manifests:
       - otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-armv7
       - otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}
     image_templates:
@@ -290,6 +313,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-s390x
   - name_template: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}
     image_templates:
@@ -298,6 +322,7 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-armv7
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-arm64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-s390x
 signs:
   - cmd: cosign

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -206,9 +206,9 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - otel/opentelemetry-collector:{{ .Version }}-riscv64
-      - otel/opentelemetry-collector:latest-riscv64
+      - otel/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Version }}-riscv64
-      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest-riscv64
+      - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-riscv64
     extra_files:
       - config.yaml
     build_flag_templates:


### PR DESCRIPTION
New Tier 3 platform: `riscv64` architecture is now included, allowing the collector to be built and distributed for this platform.

Fixes #968 