### PR TITLE
[chore] Extend the set of components that we support

### DIFF
--- a/distributions/README.md
+++ b/distributions/README.md
@@ -10,7 +10,7 @@ Distributions supported by the Collector SIG should fulfill the following criter
 2. Should meet general needs and be desired by many users.
 3. Should not be specific to any vendor.
 4. May be focused on development or proof of concept use cases.  The distribution should clearly indicate whether the Collector SIG recommends the distribution be used in production environments.
-5. Must only include components from the `opentelemetry-collector` and `opentelemetry-collector-contrib` repositories.
+5. Must only include components from the `open-telemetry` org.
     - Components that are marked [Unmaintained](https://github.com/open-telemetry/opentelemetry-collector#unmaintained) will be kept in any distributions for six months. After six months of being unmaintained the component will be removed from the distributions.
 6. Have a clearly defined list of criteria for which components are included.
 7. Must include the following assets except where the specific purpose of the distribution is naturally associated with a subset of these assets. In such cases, it should be clearly stated which assets are skipped and why.  Additional assets may be included if the maintainers agree:


### PR DESCRIPTION
The eBPF profiler does not satisfy rule (5). This is a proposed way to reconcile this.
