### PR TITLE
[chore] Use DOCKER_TOKEN_COLLECTOR_RELEASES rather than DOCKER_PASSWORD

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -211,7 +211,7 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/opampsupervisor-release.yaml
+++ b/.github/workflows/opampsupervisor-release.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    
+
     permissions:
       id-token: write
       packages: write
@@ -53,7 +53,7 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
We're going away from using a an org-wide token to use project-scoped credentials.
So this switches the Docker token from the global one to a repo-specific one (which has been set already).

See https://github.com/open-telemetry/community/issues/2805

Every distribution should already have access. But please review the mentioned issue to ensure I haven't forgotten anything.