### PR TITLE
Release Datadog Extension to Contrib

### DIFF
--- a/.chloggen/jackgopack4-datadog-extension.yaml
+++ b/.chloggen/jackgopack4-datadog-extension.yaml
@@ -7,7 +7,7 @@ change_type: new_component
 component: datadog/extension
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Release datadog extension. See README for details: https://github.com/DataDog/opentelemetry-collector-contrib/blob/main/extension/datadogextension/README.md"
+note: "Release datadog extension. See README for details: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/datadogextension/README.md"
 
 # One or more tracking issues or pull requests related to the change
 issues: []

--- a/.chloggen/jackgopack4-datadog-extension.yaml
+++ b/.chloggen/jackgopack4-datadog-extension.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: datadog/extension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Release datadog extension. See README for details: https://github.com/DataDog/opentelemetry-collector-contrib/blob/main/extension/datadogextension/README.md"
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/.chloggen/jackgopack4-datadog-extension.yaml
+++ b/.chloggen/jackgopack4-datadog-extension.yaml
@@ -10,7 +10,7 @@ component: datadog/extension
 note: "Release datadog extension. See README for details: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/datadogextension/README.md"
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [983]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -13,6 +13,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.128.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension v0.128.0


### PR DESCRIPTION
Depends upon https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40715

Add Datadog Extension to default releases for Contrib distributions.