### PR TITLE
Disable net/x/trace usage in gRPC

### DIFF
--- a/.chloggen/grpcnotrace.yaml
+++ b/.chloggen/grpcnotrace.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes usages of golang.org/x/net/trace which uses html/template and text/template in gRPC. These usages disable golang DCE.
+
+# One or more tracking issues or pull requests related to the change
+issues: [1018]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -4,6 +4,7 @@ dist:
   description: OpenTelemetry Collector Contrib
   version: 0.130.0
   output_path: ./_build
+  build_tags: "grpcnotrace"
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.130.0

--- a/distributions/otelcol-ebpf-profiler/manifest.yaml
+++ b/distributions/otelcol-ebpf-profiler/manifest.yaml
@@ -4,6 +4,7 @@ dist:
   description: OpenTelemetry Collector for eBPF Profiling
   version: 0.130.0
   output_path: ./_build
+  build_tags: "grpcnotrace"
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.130.0

--- a/distributions/otelcol-k8s/manifest.yaml
+++ b/distributions/otelcol-k8s/manifest.yaml
@@ -4,6 +4,7 @@ dist:
   description: OpenTelemetry Collector for Kubernetes
   version: 0.130.0
   output_path: ./_build
+  build_tags: "grpcnotrace"
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.130.0

--- a/distributions/otelcol-otlp/manifest.yaml
+++ b/distributions/otelcol-otlp/manifest.yaml
@@ -4,6 +4,7 @@ dist:
   description: OpenTelemetry Collector OTLP
   version: 0.130.0
   output_path: ./_build
+  build_tags: "grpcnotrace"
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.130.0

--- a/distributions/otelcol/manifest.yaml
+++ b/distributions/otelcol/manifest.yaml
@@ -4,6 +4,7 @@ dist:
   description: OpenTelemetry Collector
   version: 0.130.0
   output_path: ./_build
+  build_tags: "grpcnotrace"
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.130.0


### PR DESCRIPTION
Removes usages of golang.org/x/net/trace which uses `html/template` and `text/template` in gRPC. These usages disable golang DCE.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/12747

See https://github.com/grpc/grpc-go/pull/6954