### PR TITLE
[chore] remove faulty renovate config for goreleaser-pro

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -139,25 +139,6 @@
       "enabled": false
     },
     {
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchPackageNames": [
-        "goreleaser/goreleaser-pro"
-      ],
-      "extractVersion": "^(?<version>.*)-pro$"
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "github.com/goreleaser/goreleaser-pro/v2",
-        "github.com/goreleaser/goreleaser-pro"
-      ],
-      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?-(?<compatibility>.*)$"
-    },
-    {
       "matchPackageNames": [
         "goreleaser/goreleaser-pro",
         "github.com/goreleaser/goreleaser-pro/v2",


### PR DESCRIPTION
This PR removes some old and now faulty renovate config that allowed compatibility with goreleaser-pro versions that were named like `vX.Y.Z-pro` until recently, but are now named normally, e.g. `vX.Y.Z`