### PR TITLE
[chore] remove redundant goreleaser settings

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -103,9 +103,6 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
 release:
   make_latest: false
-  github:
-    owner: open-telemetry
-    name: opentelemetry-collector-releases
   header: |
     ### Images and binaries for collector distributions here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
 archives:

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -103,9 +103,6 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
 release:
   make_latest: false
-  github:
-    owner: open-telemetry
-    name: opentelemetry-collector-releases
   header: |
     ### Release of OpAMP supervisor artifacts
 archives:


### PR DESCRIPTION
This PR removes the redundant `github:` settings from goreleaser configs of OCB and OpAMP supervisor. Goreleaser will by default always take the current repo.