### PR TITLE
[chore] use standard GH token for releases

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -40,6 +40,8 @@ jobs:
           - GOOS: darwin
             GOARCH: arm
     runs-on: ${{ inputs.runner_os }}
+    permissions:
+      packages: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -110,7 +110,7 @@ jobs:
           GOAMD64: v1
           GOPPC64: power8
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_YES: true
 
       - name: Move built artifacts
@@ -133,7 +133,7 @@ jobs:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
           GOARM: 7 # Default is 6
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_YES: true
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 


### PR DESCRIPTION
Extracted out of #1016 based on https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1016#discussion_r2230590493

[Tested successfully on my fork](https://github.com/mowies/opentelemetry-collector-releases/actions/runs/16562360126)