### PR TITLE
Revert "[chore] remove redundant goreleaser settings (#1041)"

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -103,6 +103,9 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-builder:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
 release:
   make_latest: false
+  github:
+    owner: open-telemetry
+    name: opentelemetry-collector-releases
   header: |
     ### Images and binaries for collector distributions here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
 archives:

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -103,6 +103,9 @@ docker_manifests:
       - ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:{{ .Env.CONTAINER_IMAGE_EPHEMERAL_TAG }}-ppc64le
 release:
   make_latest: false
+  github:
+    owner: open-telemetry
+    name: opentelemetry-collector-releases
   header: |
     ### Release of OpAMP supervisor artifacts
 archives:


### PR DESCRIPTION
#1041 should be reverted because it is blocking the collector snapshot build, as seen in #13493, #13494, and #13296. 
It does not work as expected because we do not trigger releases from opentelemetry-collector-releases; 

instead, releases are triggered in open-telemetry-collector. In that workflow, the release repository is checked out, and only if release.github.name is empty will the current repository’s .git be used.