### PR TITLE
[chore] Promote @mowies to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [Bogdan Drutu](https://github.com/bogdandrutu), Snowflake
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Evan Bradley](https://github.com/evan-bradley), Dynatrace
+- [Moritz Wiesinger](https://github.com/mowies), Dynatrace
 - [Pablo Baeyens](https://github.com/mx-psi), DataDog
 - [Sean Marciniak](https://github.com/MovieStoreGuy), Splunk
 - [Tyler Helmuth](https://github.com/TylerHelmuth), Honeycomb
@@ -50,7 +51,6 @@ For more information about the maintainer role, see the [community repository](h
 - [David Ashpole](https://github.com/dashpole), Google
 - [John L. Peterson (Jack)](https://github.com/jackgopack4), Datadog
 - [Matt Wear](https://github.com/mwear), Lightstep
-- [Moritz Wiesinger](https://github.com/mowies), Dynatrace
 - [Sam DeHaan](https://github.com/dehaansa), Grafana Labs
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 


### PR DESCRIPTION
@mowies has made tremendous amount of contributions to the opentelemetry-collector-releases repo:

PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-releases/pulls?q=is%3Apr+reviewed-by%3Amowies+
PRs authored: https://github.com/open-telemetry/opentelemetry-collector-releases/pulls?q=is%3Apr+author%3Amowies+
Issues created: https://github.com/open-telemetry/opentelemetry-collector-releases/issues?q=is%3Aissue+author%3Amowies+
Issues commented: https://github.com/open-telemetry/opentelemetry-collector-releases/issues?q=is%3Aissue+commenter%3Amowies+
Commits: https://github.com/open-telemetry/opentelemetry-collector-releases/commits?author=mowies&since=2023-05-31&until=now

We would like to promote @mowies to Maintainer