### PR TITLE
[chore] re-introduce new dockerhub token

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -101,8 +101,8 @@ jobs:
       - name: Log into Docker.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -236,8 +236,8 @@ jobs:
       - name: Log into Docker.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -10,13 +10,13 @@ jobs:
     name: Check docker token
     runs-on: ubuntu-22.04
     steps:
-      - name: Log into Docker.io
+      - name: Log into Docker.io using old token
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Log into Docker.io using new token
+      - name: Log into Docker.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/release-builder.yaml
+++ b/.github/workflows/release-builder.yaml
@@ -81,8 +81,8 @@ jobs:
       - name: Log into Docker.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/.github/workflows/release-opampsupervisor.yaml
+++ b/.github/workflows/release-opampsupervisor.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    
+
     permissions:
       id-token: write
       packages: write
@@ -81,8 +81,8 @@ jobs:
       - name: Log into Docker.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_COLLECTOR_RELEASES }}
       - name: Login to GitHub Package Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
This reverts commit 8f30d8c1111ff5a727e3c000955527df21a79cdf.

Fixes #1053 

Re-introduction should be possible now that the new permissions were added to the token. (see [link](https://github.com/open-telemetry/community/issues/2805#issuecomment-3136658536))