### PR TITLE
[chore] make CI more parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
-    strategy: 
+    strategy:
+      fail-fast: false
       matrix:
         distro:
           - otelcol

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,3 +39,9 @@ jobs:
         run: make ci
         env:
           DISTRIBUTIONS: ${{ matrix.distro }}
+
+  build-result:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo "Build for all distros succeeded"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
           DISTRIBUTIONS: ${{ matrix.distro }}
 
   build-result:
+    name: "Build Result"
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    strategy: 
+      matrix:
+        distro:
+          - otelcol
+          - otelcol-contrib
+          - otelcol-k8s
+          - otelcol-otlp
+          - otelcol-ebpf-profiler
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -28,3 +36,5 @@ jobs:
 
       - name: Verify
         run: make ci
+        env:
+          DISTRIBUTIONS: ${{ matrix.distro }}


### PR DESCRIPTION
this PR optimizes pipelines a little bit by making the CI pipelines more parallelized

TODO:
- remove the "Build" job from required jobs for merges
- merge this PR
- add the "build-result" job instead to the required jobs for merges