### PR TITLE
[chore] use commit sha instead of timestamp for nightly releases

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -142,6 +142,6 @@ sboms:
   - id: package
     artifacts: package
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-builder
   keep_single_release: true

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -324,7 +324,7 @@ func (b *distributionBuilder) WithNightlyConfig() *distributionBuilder {
 
 func (b *distributionBuilder) nightly() config.Nightly {
 	return config.Nightly{
-		VersionTemplate:   "{{ incpatch .Version}}-nightly.{{ .Now.Format \"200601021504\" }}",
+		VersionTemplate:   "{{ incpatch .Version}}-nightly.{{ .ShortCommit }}",
 		TagName:           fmt.Sprintf("nightly-%s", b.dist.name),
 		PublishRelease:    false,
 		KeepSingleRelease: true,

--- a/cmd/opampsupervisor/.goreleaser.yml
+++ b/cmd/opampsupervisor/.goreleaser.yml
@@ -142,7 +142,7 @@ sboms:
   - id: package
     artifacts: package
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-opamp-supervisor
   keep_single_release: true
     

--- a/distributions/otelcol-contrib/.goreleaser-build.yaml
+++ b/distributions/otelcol-contrib/.goreleaser-build.yaml
@@ -60,6 +60,6 @@ monorepo:
 partial:
   by: target
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-otelcol-contrib
   keep_single_release: true

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -331,6 +331,6 @@ monorepo:
 partial:
   by: target
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-otelcol-contrib
   keep_single_release: true

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -211,6 +211,6 @@ monorepo:
 partial:
   by: target
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-otelcol-k8s
   keep_single_release: true

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -306,6 +306,6 @@ monorepo:
 partial:
   by: target
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-otelcol-otlp
   keep_single_release: true

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -326,6 +326,6 @@ monorepo:
 partial:
   by: target
 nightly:
-  version_template: '{{ incpatch .Version}}-nightly.{{ .Now.Format "200601021504" }}'
+  version_template: '{{ incpatch .Version}}-nightly.{{ .ShortCommit }}'
   tag_name: nightly-otelcol
   keep_single_release: true


### PR DESCRIPTION
Fixes #1065 

The nightly release failed because of a mismatch between nightly versions that goreleaser used during the 2 step release in base-release.yml
It used both 202507311344 and 202507311345 as timestamps since the nightlies::version_template is set to include a timestamp. This is changed here, and now we use the commit hash instead since that is deterministic, unlike the timestamp.