### PR TITLE
Pins go.opentelemetry.io/otel/exporters/prometheus to v0.58.0

### DIFF
--- a/.chloggen/prometheus-exporter.yaml
+++ b/.chloggen/prometheus-exporter.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service/telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Pins go.opentelemetry.io/otel/exporters/prometheus to v0.58.0"
+
+# One or more tracking issues or pull requests related to the change
+issues: [1067]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "go.opentelemetry.io/otel/exporters/prometheus v0.59.x has a bug leading to unexpected suffix in metric names, we want to stay with v0.58.0 in the artifacts."
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -262,3 +262,4 @@ providers:
 replaces:
   # see https://github.com/openshift/api/pull/1515
   - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
+  - go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -262,4 +262,5 @@ providers:
 replaces:
   # see https://github.com/openshift/api/pull/1515
   - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
+  # see https://github.com/open-telemetry/opentelemetry-collector/pull/13466
   - go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0

--- a/distributions/otelcol-ebpf-profiler/manifest.yaml
+++ b/distributions/otelcol-ebpf-profiler/manifest.yaml
@@ -35,3 +35,4 @@ providers:
 replaces:
   # see https://github.com/openshift/api/pull/1515
   - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
+  - go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0

--- a/distributions/otelcol-k8s/manifest.yaml
+++ b/distributions/otelcol-k8s/manifest.yaml
@@ -89,3 +89,6 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.37.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.37.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.37.0
+
+replaces:
+  - go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0

--- a/distributions/otelcol-otlp/manifest.yaml
+++ b/distributions/otelcol-otlp/manifest.yaml
@@ -16,3 +16,6 @@ receivers:
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.37.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.37.0
+
+replaces:
+  - go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0

--- a/distributions/otelcol/manifest.yaml
+++ b/distributions/otelcol/manifest.yaml
@@ -51,3 +51,6 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.37.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.37.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.37.0
+
+replaces:
+  - go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0


### PR DESCRIPTION
Context: https://github.com/open-telemetry/opentelemetry-collector/pull/13466

go.opentelemetry.io/otel/exporters/prometheus v0.59.x has a bug leading to unexpected suffix in metric names, we want to stay with v0.58.0 in the artifacts.