### PR TITLE
[chore] fix OCB version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GORELEASER ?= goreleaser
 
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
-OTELCOL_BUILDER_VERSION ?= 0.131.1
+OTELCOL_BUILDER_VERSION ?= 0.131.0
 OTELCOL_BUILDER_DIR ?= ${HOME}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 


### PR DESCRIPTION
OCB does not have `0.131.1` , should still be on `0.131.0`