### PR TITLE
[chore] add riscv64 to k8s release pipeline

### DIFF
--- a/.github/workflows/release-k8s.yaml
+++ b/.github/workflows/release-k8s.yaml
@@ -11,7 +11,7 @@ jobs:
     with:
       distribution: otelcol-k8s
       goos: '[ "linux" ]'
-      goarch: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
+      goarch: '[ "amd64", "arm64", "ppc64le", "riscv64", "s390x" ]'
       nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all


### PR DESCRIPTION
Fixes #1089

Adding `riscv64` to the k8s release pipeline was missed during the initial PR to add the architecture (#969)