### PR TITLE
[chore] fix otelbot github app using wrong app ID

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -30,7 +30,7 @@ jobs:
         id: otelbot-token
         with:
           app-id: ${{ vars.OTELBOT_COLLECTOR_RELEASES_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          private-key: ${{ secrets.OTELBOT_COLLECTOR_RELEASES_PRIVATE_KEY }}
 
       # The next 2 steps are taken from # from https://github.com/actions/create-github-app-token#create-a-git-committer-string-for-an-app-installation
       - name: Get GitHub App User ID


### PR DESCRIPTION
Fixes #1111

The wrong App ID was used to get a token and therefore also the wrong token was provided I think.

The correct ID was provided [here](https://github.com/open-telemetry/community/issues/2882#issuecomment-3128033618).