### PR TITLE
[chore] fix tag name issue in binary release pipeline (#1126)

### DIFF
--- a/.github/workflows/base-binary-release.yaml
+++ b/.github/workflows/base-binary-release.yaml
@@ -36,23 +36,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set goreleaser last tag reference in case of non-nightly release
-        id: prev-tag
-        if: ${{ !contains(github.ref, '-nightly') }}
-        # find previous tag by taking only binary tags, filtering out nightly tags and then choosing the
-        # second to last tag (last one is the current release)
-        run: |
-          prev_tag=$(git tag | grep "cmd/${{ inputs.binary }}" | grep -v "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
-          current_tag="cmd/${{ inputs.binary }}/${{ github.ref }}"
-          echo "PREVIOUS_RELEASE_TAG=$prev_tag" >> "$GITHUB_OUTPUT"
-          echo "CURRENT_TAG=$current_tag" >> "$GITHUB_OUTPUT"
-
-      - name: Set nightly enabled
-        id: nightly-check
-        if: ${{ contains(github.ref, '-nightly') }}
-        run: |
-          echo "NIGHTLY_FLAG=--nightly" >> "$GITHUB_OUTPUT"
-
       - name: Set COLLECTOR_REF
         id: collector-ref
         run: |
@@ -70,6 +53,23 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git tag -a "${tag}" -m "${message}"
           git push origin "${tag}"
+
+      - name: Set goreleaser last tag reference in case of non-nightly release
+        id: prev-tag
+        if: ${{ !contains(github.ref, '-nightly') }}
+        # find previous tag by taking only binary tags, filtering out nightly tags and then choosing the
+        # second to last tag (last one is the current release)
+        run: |
+          prev_tag=$(git tag | grep "cmd/${{ inputs.binary }}" | grep -v "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
+          current_tag="cmd/${{ inputs.binary }}/${{ github.ref_name }}"
+          echo "PREVIOUS_RELEASE_TAG=$prev_tag" >> "$GITHUB_OUTPUT"
+          echo "CURRENT_TAG=$current_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Set nightly enabled
+        id: nightly-check
+        if: ${{ contains(github.ref, '-nightly') }}
+        run: |
+          echo "NIGHTLY_FLAG=--nightly" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Collector dependency repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
This backports https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1126 onto the release branch for 0.132.x