### PR TITLE
[chore] add missing job dependency to prev-tag job

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -177,7 +177,9 @@ jobs:
   release:
     name: Release
     runs-on: ${{ inputs.runner_os }}
-    needs: prepare
+    needs:
+      - prepare
+      - prev-tag
 
     permissions:
       id-token: write


### PR DESCRIPTION
This adds a missing dependency to the new `prev-tag` job to make sure that outputs are set correctly.