### PR TITLE
Add explicit token permissions for base-ci-goreleaser workflow

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -28,6 +28,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 env:
   # renovate: datasource=github-releases depName=goreleaser/goreleaser-pro
   GORELEASER_PRO_VERSION: v2.11.2


### PR DESCRIPTION
This workflow deserves special attention because it uses ${{ github.token }}, but only for reading, which should always be allowed on public repos.

```
        env:
          GH_TOKEN: ${{ github.token }}
        run: |
          run_id=$(gh run list \
            --branch main \
            --workflow build-and-test \
            --repo open-telemetry/opentelemetry-collector-contrib \
            --limit 1 \
            --status success \
            --json databaseId \
            --jq '.[0].databaseId' \
          )
```