### PR TITLE
Add explicit token permissions for base release workflow

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -21,6 +21,9 @@ on:
         type: string
         default: false
 
+permissions:
+  contents: read
+
 env:
   # renovate: datasource=github-releases depName=goreleaser/goreleaser-pro
   GORELEASER_PRO_VERSION: v2.11.2


### PR DESCRIPTION
Part of https://github.com/open-telemetry/sig-security/issues/148

Extracted into a separate PR for extra safety before the next release by running nightly releases with it.