### PR TITLE
[chore] remove unneeded pipeline token

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -23,8 +23,6 @@ jobs:
       contents: write # required for pushing changes
       pull-requests: write # required for creating PR
 
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         id: otelbot-token


### PR DESCRIPTION
This token is not needed anymore since the token is directly fetched in `otelbot-token` and then used for the rest of the workflow