### PR TITLE
Fix GitHub token env variable naming

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           .github/workflows/scripts/bump-versions.sh --commit --pull-request
         env:
-          GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           next_beta_core: ${{ github.event.inputs.next_beta_core }}
           next_beta_contrib: ${{ github.event.inputs.next_beta_contrib }}
           next_stable_core: ${{ github.event.inputs.next_stable_core }}


### PR DESCRIPTION
Not sure why this is broken, this will maybe fix it.
This PR should fix this issue: https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/17097314369/job/48484670905