### PR TITLE
[chore] update deprecated goreleaser fields

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -271,12 +271,12 @@ func (b *distributionBuilder) WithBinArchive() *distributionBuilder {
 	return b
 }
 
-func (b *distributionBuilder) newArchives(dist string, builds []string) []config.Archive {
+func (b *distributionBuilder) newArchives(dist string, ids []string) []config.Archive {
 	return []config.Archive{
 		{
 			ID:           dist,
 			NameTemplate: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}",
-			Builds:       builds,
+			IDs:          ids,
 		},
 	}
 }
@@ -303,7 +303,7 @@ func (b *distributionBuilder) newNfpms(dist string) []config.NFPM {
 	return []config.NFPM{
 		{
 			ID:          dist,
-			Builds:      []string{dist + "-linux"},
+			IDs:         []string{dist + "-linux"},
 			Formats:     []string{"deb", "rpm"},
 			License:     "Apache 2.0",
 			Description: fmt.Sprintf("OpenTelemetry Collector - %s", dist),

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -70,11 +70,11 @@ builds:
       path: artifacts/otelcol-contrib-windows_{{ .Target }}/otelcol-contrib.exe
 archives:
   - id: otelcol-contrib
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
-    builds:
+    ids:
       - otelcol-contrib-linux
       - otelcol-contrib-darwin
       - otelcol-contrib-windows
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
   - package_name: otelcol-contrib
     contents:
@@ -95,14 +95,14 @@ nfpms:
         dependencies:
           - /bin/sh
     id: otelcol-contrib
+    ids:
+      - otelcol-contrib-linux
     formats:
       - deb
       - rpm
     maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
     description: OpenTelemetry Collector - otelcol-contrib
     license: Apache 2.0
-    builds:
-      - otelcol-contrib-linux
 checksum:
   name_template: '{{ .ProjectName }}_otelcol-contrib{{ if eq .Runtime.Goos "windows" }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
 dockers:

--- a/distributions/otelcol-ebpf-profiler/.goreleaser.yaml
+++ b/distributions/otelcol-ebpf-profiler/.goreleaser.yaml
@@ -26,9 +26,9 @@ builds:
       - '{{ .Env.BUILD_FLAGS }}'
 archives:
   - id: otelcol-ebpf-profiler
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
-    builds:
+    ids:
       - otelcol-ebpf-profiler-linux
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 checksum:
   name_template: '{{ .ProjectName }}_otelcol-ebpf-profiler{{ if eq .Runtime.Goos "windows" }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
 dockers:

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -40,10 +40,10 @@ builds:
       - '{{ .Env.BUILD_FLAGS }}'
 archives:
   - id: otelcol-k8s
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
-    builds:
+    ids:
       - otelcol-k8s-linux
       - otelcol-k8s-windows
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 checksum:
   name_template: '{{ .ProjectName }}_otelcol-k8s{{ if eq .Runtime.Goos "windows" }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
 dockers:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -64,11 +64,11 @@ builds:
       - '{{ .Env.BUILD_FLAGS }}'
 archives:
   - id: otelcol-otlp
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
-    builds:
+    ids:
       - otelcol-otlp-linux
       - otelcol-otlp-darwin
       - otelcol-otlp-windows
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
   - package_name: otelcol-otlp
     contents:
@@ -86,14 +86,14 @@ nfpms:
         dependencies:
           - /bin/sh
     id: otelcol-otlp
+    ids:
+      - otelcol-otlp-linux
     formats:
       - deb
       - rpm
     maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
     description: OpenTelemetry Collector - otelcol-otlp
     license: Apache 2.0
-    builds:
-      - otelcol-otlp-linux
 checksum:
   name_template: '{{ .ProjectName }}_otelcol-otlp{{ if eq .Runtime.Goos "windows" }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
 dockers:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -65,11 +65,11 @@ builds:
       - '{{ .Env.BUILD_FLAGS }}'
 archives:
   - id: otelcol
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
-    builds:
+    ids:
       - otelcol-linux
       - otelcol-darwin
       - otelcol-windows
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
 nfpms:
   - package_name: otelcol
     contents:
@@ -90,14 +90,14 @@ nfpms:
         dependencies:
           - /bin/sh
     id: otelcol
+    ids:
+      - otelcol-linux
     formats:
       - deb
       - rpm
     maintainer: The OpenTelemetry Collector maintainers <cncf-opentelemetry-maintainers@lists.cncf.io>
     description: OpenTelemetry Collector - otelcol
     license: Apache 2.0
-    builds:
-      - otelcol-linux
 checksum:
   name_template: '{{ .ProjectName }}_otelcol{{ if eq .Runtime.Goos "windows" }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
 dockers:


### PR DESCRIPTION
This PR updates some deprecated fields in the goreleaser configs.
See [link](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/17128206347/job/48585077753#step:16:34) for the deprecation warnings.