### PR TITLE
Use correct GORELEASE tags for all the gorelease actions.

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -170,6 +170,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_YES: true
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
Skipping changelog since this is not an external change. The problem is that if we have a failure with a previously added tag, we cannot re-run that action because it will read the latest tag added instead of the one that triggered the action.

Here is how to reproduce the problem:
1. Add a tag T1 -> action fails (for some reasons).
1. Add a tag T2 (nightly for example) and triggers a new build;
1. If you try to re-run the action triggered by T1 will read T2 as the current tag

To explain more what happened in 134 release:
1. The upgrade PR for 133-134 landed at 5:24PM - PST
2. The nightly tag `v0.134.0-nightly.202508310234` landed at 7:34PM - PST on the upgrade PR
3. The release tag `v0.134.0` landed at 9:22PM - PST on the upgrade PR (there was a failure to add to the right commit, but that will not affect this since release did not happened on that PR and GH actions fails with the right tag at right commit)

The release Action Item (on windows) trigger by the tag `v0.134.0` reads the nightly tag instead of the release `v0.134.0` from that commit.