### PR TITLE
[chore] Add explicit token permission

### DIFF
--- a/.github/workflows/base-ci-binary.yaml
+++ b/.github/workflows/base-ci-binary.yaml
@@ -18,6 +18,9 @@ on:
         default: ""
         description: "The collector dependency will be put into this folder"
 
+permissions:
+  contents: read
+
 env:
   # renovate: datasource=github-releases depName=goreleaser/goreleaser-pro
   GORELEASER_PRO_VERSION: v2.12.0


### PR DESCRIPTION
It looks like it's just testing the release workflow (but not doing the release)? so I think it doesn't need any special token permissions(?)

Resolves
- https://github.com/open-telemetry/opentelemetry-collector-releases/security/code-scanning/69