### PR TITLE
chore: fix bump-versions

### DIFF
--- a/.github/workflows/scripts/bump-versions.sh
+++ b/.github/workflows/scripts/bump-versions.sh
@@ -40,6 +40,7 @@ create_pr=false
 next_beta_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}' distributions/otelcol/manifest.yaml)
 next_beta_contrib=$(awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}' distributions/otelcol-contrib/manifest.yaml)
 next_stable_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}' distributions/otelcol/manifest.yaml)
+
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --commit) commit_changes=true ;;

--- a/.github/workflows/scripts/bump-versions.sh
+++ b/.github/workflows/scripts/bump-versions.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -e
-# This script reads current versions and takes optional next versions, and updates the
-# version in the specified files. If next version is not provided, it will infer the
-# next semantic version (e.g. v0.110.0 -> v0.111.0 or v1.16.0 -> v1.17.0) based on the
-# current version(s) read in.
+# This script reads next versions, and updates the version in the specified files.
+# It will infer the next semantic version (e.g. v0.110.0 -> v0.111.0 or v1.16.0 -> v1.17.0)
+# based on the version(s) read in.
 
 # List of files to update
 manifest_files=(
@@ -16,10 +15,7 @@ manifest_files=(
 
 # Function to display usage
 usage() {
-  echo "Usage: $0 [--commit] [--pull-request] [--next-beta-core <next-beta-core>] [--next-beta-contrib <next-beta-contrib>] [--next-stable-core <next-stable-core>]"
-  echo "  --next-beta-core: Next beta version of the core component (e.g., v0.111.0)"
-  echo "  --next-beta-contrib: Next beta version of the contrib component (e.g., v0.111.0)"
-  echo "  --next-stable-core: Next stable version of the core component (e.g., v1.17.0)"
+  echo "Usage: $0 [--commit] [--pull-request]"
   echo
   echo "  --commit: Commit the changes to a new branch"
   echo "  --pull-request: Push the changes to the repo and create a draft PR (requires --commit)"
@@ -41,14 +37,11 @@ validate_and_strip_version() {
 commit_changes=false
 create_pr=false
 # Parse named arguments
-current_beta_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}' distributions/otelcol/manifest.yaml)
-current_beta_contrib=$(awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}' distributions/otelcol-contrib/manifest.yaml)
-current_stable=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}' distributions/otelcol/manifest.yaml)
+next_beta_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}' distributions/otelcol/manifest.yaml)
+next_beta_contrib=$(awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}' distributions/otelcol-contrib/manifest.yaml)
+next_stable_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}' distributions/otelcol/manifest.yaml)
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    --next-beta-core) next_beta_core="$2"; shift ;;
-    --next-beta-contrib) next_beta_contrib="$2"; shift ;;
-    --next-stable-core) next_stable_core="$2"; shift ;;
     --commit) commit_changes=true ;;
     --pull-request) create_pr=true ;;
     *) echo "Unknown parameter passed: $1"; usage ;;
@@ -63,15 +56,6 @@ if [ "$create_pr" = true ] && [ "$commit_changes" = false ]; then
 fi
 
 # Validate and strip versions
-if [ -n "$current_beta_core" ]; then
-  validate_and_strip_version current_beta_core
-fi
-if [ -n "$current_beta_contrib" ]; then
-  validate_and_strip_version current_beta_contrib
-fi
-if [ -n "$current_stable" ]; then
-  validate_and_strip_version current_stable
-fi
 if [ -n "$next_beta_core" ]; then
   validate_and_strip_version next_beta_core
 fi
@@ -110,40 +94,15 @@ max_version() {
   echo "$version1"
 }
 
-# Function to bump the minor version and reset patch version to 0
-bump_version() {
-  local version=$1
-  local major
-  major=$(echo "$version" | cut -d. -f1)
-  local minor
-  minor=$(echo "$version" | cut -d. -f2)
-  local new_minor
-  new_minor=$((minor + 1))
-  echo "$major.$new_minor.0"
-}
-
-# Infer the next beta version if not supplied
-if  [ -n "$current_beta_core" ] && [ -z "$next_beta_core" ]; then
-  next_beta_core=$(bump_version "$current_beta_core")
-fi
-if  [ -n "$current_beta_contrib" ] && [ -z "$next_beta_contrib" ]; then
-  next_beta_contrib=$(bump_version "$current_beta_contrib")
-fi
-
 # Determine the maximum of next_beta_core and next_beta_contrib
 next_distribution_version=$(max_version "$next_beta_core" "$next_beta_contrib")
 validate_and_strip_version next_distribution_version
 
-# Infer the next stable version if current_stable provided and next version not supplied
-if [ -n "$current_stable" ] && [ -z "$next_stable_core" ]; then
-  next_stable_core=$(bump_version "$current_stable")
-fi
-
 # Update versions in each manifest file
 echo "Making the following updates:"
-echo "  - core beta module set from $current_beta_core to $next_beta_core"
-echo "  - core stable module set from $current_stable to $next_stable_core"
-echo "  - contrib beta module set from $current_beta_contrib to $next_beta_contrib"
+echo "  - core beta module set to $next_beta_core"
+echo "  - core stable module set to $next_stable_core"
+echo "  - contrib beta module set to $next_beta_contrib"
 echo "  - distribution version to $next_distribution_version"
 for file in "${manifest_files[@]}"; do
   if [ -f "$file" ]; then
@@ -166,50 +125,48 @@ if [ "$commit_changes" = false ]; then
 fi
 
 commit_changes() {
-  local current_version=$1
-  local next_version=$2
-  shift 2
+  local next_version=$1
+  shift 1
   local branch_name="update-version-${next_version}"
 
   git checkout -b "$branch_name"
   git add .
-  git commit -m "Update version from $current_version to $next_version"
+  git commit -m "Update version to $next_version"
   git push -u origin "$branch_name"
 }
 
 create_pr() {
-  local current_version=$1
-  local next_version=$2
-  shift 2
+  local next_version=$1
+  shift 1
   local branch_name="update-version-${next_version}"
 
   gh pr create --title "[chore] Prepare release $next_version" \
-    --body "This PR updates the version from $current_version to $next_version" \
+    --body "This PR updates the version to $next_version" \
     --base main --head "$branch_name"
 }
 
 # TODO: Once Collector 1.0 is released, we can consider removing the
 # beta version check for commit and PR creation
-if [ -n "$current_beta_core" ]; then
+if [ -n "$next_beta_core" ]; then
   if [ "$commit_changes" = true ]; then
-    commit_changes "$current_beta_core" "$next_beta_core"
+    commit_changes "$next_beta_core"
   fi
   if [ "$create_pr" = true ]; then
-    create_pr "$current_beta_core" "$next_beta_core"
+    create_pr "$next_beta_core"
   fi
-elif [ -n "$current_beta_contrib" ]; then
+elif [ -n "$next_beta_contrib" ]; then
   if [ "$commit_changes" = true ]; then
-    commit_changes "$current_beta_contrib" "$next_beta_contrib"
+    commit_changes "$next_beta_contrib"
   fi
   if [ "$create_pr" = true ]; then
-    create_pr "$current_beta_contrib" "$next_beta_contrib"
+    create_pr "$next_beta_contrib"
   fi
 else
   if [ "$commit_changes" = true ]; then
-    commit_changes "$current_stable" "$next_stable_core"
+    commit_changes "$next_stable_core"
   fi
   if [ "$create_pr" = true ]; then
-    create_pr "$current_stable" "$next_stable_core"
+    create_pr "$next_stable_core"
   fi
 fi
 

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,19 +1,6 @@
 name: Update Version in Distributions and Prepare PR
 on:
   workflow_dispatch:
-    inputs:
-      next_beta_core:
-        description: 'Collector core beta module set version to update to. Leave empty to bump to next minor version (e.g. 0.120.1 -> 0.121.0)'
-        required: false
-        default: ''
-      next_beta_contrib:
-        description: 'Collector contrib beta module set version to update to. Leave empty to bump to next minor version (e.g. 0.120.1 -> 0.121.0)'
-        required: false
-        default: ''
-      next_stable_core:
-        description: 'Collector core stable module set version to update to. Leave empty to bump to next minor version (e.g. 1.26.0 -> 1.27.0)'
-        required: false
-        default: ''
 
 permissions:
   contents: read
@@ -49,6 +36,3 @@ jobs:
           .github/workflows/scripts/bump-versions.sh --commit --pull-request
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          next_beta_core: ${{ github.event.inputs.next_beta_core }}
-          next_beta_contrib: ${{ github.event.inputs.next_beta_contrib }}
-          next_stable_core: ${{ github.event.inputs.next_stable_core }}


### PR DESCRIPTION
This PR fixes an issue during release where the manifest version of distros was updated to one version to far.
Since the component versions are now bumped by renovate, the bump-versions script doesn't need to be concerned with them anymore and therefore needs to do less things in general.

Fixes #1186