### PR TITLE
ebpf-profiler: change SamplesPerSecond to samples_per_second

### DIFF
--- a/tests/docker-tests/ebpf-profiler-config.yaml
+++ b/tests/docker-tests/ebpf-profiler-config.yaml
@@ -1,6 +1,6 @@
 receivers:
   profiling:
-    SamplesPerSecond: 19
+    samples_per_second: 19
 
 exporters:
   otlphttp:


### PR DESCRIPTION
With recent changes, SamplesPerSecond got replaced by samples_per_second in the configuration.