### PR TITLE
[chore] attempt to fix validate-components.sh per #1211

### DIFF
--- a/scripts/validate-components.sh
+++ b/scripts/validate-components.sh
@@ -70,7 +70,7 @@ while IFS= read -r manifest_file; do
 
   # Compare each manifest component against the valid list
   while IFS= read -r component; do
-    if ! printf '%s\n' "$valid_components" | grep -qxF "$component"; then
+    if ! grep -qxF "$component" <<< "$valid_components"; then
       invalid_components="${invalid_components}\n${component}"
     fi
   done <<< "$manifest_components"


### PR DESCRIPTION
attempts to modify "validate-components.sh" to avoid intermittent failures from broken pipe in #1211 

This fixes intermittent “printf: write error: Broken pipe” by replacing printf ... | grep -q with a bash here-string (grep -q <<< "$valid_components"). grep -q can exit early and close the pipe, causing printf to receive SIGPIPE; the here-string eliminates the pipeline while preserving the exact full-line match semantics.