### PR TITLE
[chore] upgrade cosign-installer action to v4.0.0

### DIFF
--- a/.github/workflows/base-binary-release.yaml
+++ b/.github/workflows/base-binary-release.yaml
@@ -86,6 +86,8 @@ jobs:
         run: cp cmd/${{ inputs.binary }}/Dockerfile ${{ inputs.dependency-target-folder }}/cmd/${{ inputs.binary }}/Dockerfile
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: "v2.6.1"
 
       - uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
 

--- a/.github/workflows/base-ci-binary.yaml
+++ b/.github/workflows/base-ci-binary.yaml
@@ -50,6 +50,8 @@ jobs:
         run: cp cmd/${{ inputs.binary }}/Dockerfile ${{ inputs.dependency-target-folder }}/cmd/${{ inputs.binary }}/Dockerfile
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: "v2.6.1"
 
       - uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
 

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -72,6 +72,8 @@ jobs:
           fetch-depth: 0
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: "v2.6.1"
 
       - uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
 
@@ -196,6 +198,8 @@ jobs:
           fetch-depth: 0
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: "v2.6.1"
 
       - uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
 


### PR DESCRIPTION
This upgrades the cosign-installer action to v4 but pins the cosign binary version to 2.6.1

There are some breaking changes in cosign v3 which I want to prevent for now as they will impact release signing operations in this repo. More info about goreleaser compatibility [here](https://github.com/goreleaser/goreleaser/issues/6195) and the cosign breaking changes [here](https://blog.sigstore.dev/cosign-3-0-available/).