### PR TITLE
[chore] Remove msi from opamp binary distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ goreleaser-verify: goreleaser
 
 ensure-goreleaser-up-to-date: generate-goreleaser
 	@git diff -s --exit-code distributions/*/.goreleaser.yaml || (echo "Check failed: The goreleaser templates have changed but the .goreleaser.yamls haven't. Run 'make generate-goreleaser' and update your PR." && exit 1)
+	@git diff -s --exit-code cmd/*/.goreleaser.yaml || (echo "Check failed: The goreleaser templates have changed but the .goreleaser.yamls haven't. Run 'make generate-goreleaser' and update your PR." && exit 1)
 
 validate-components:
 	@./scripts/validate-components.sh

--- a/cmd/goreleaser/internal/distro_opamp.go
+++ b/cmd/goreleaser/internal/distro_opamp.go
@@ -32,7 +32,6 @@ var (
 	}).withBinaryPackagingDefaults().
 		withBinaryMonorepo(".contrib/cmd/opampsupervisor").
 		withDefaultBinaryRelease(opampReleaseHeader).
-		withDefaultMSIConfig().
 		withDefaultNfpms().
 		// This is required because of some non-obvious path/workdir handling in
 		// Github Actions specific to the binaries CI.
@@ -49,10 +48,6 @@ var (
 			d.Nfpms[0].Scripts.PreInstall = path.Join("cmd", d.Name, d.Nfpms[0].Scripts.PreInstall)
 			d.Nfpms[0].Scripts.PostInstall = path.Join("cmd", d.Name, d.Nfpms[0].Scripts.PostInstall)
 			d.Nfpms[0].Scripts.PreRemove = path.Join("cmd", d.Name, d.Nfpms[0].Scripts.PreRemove)
-
-			for i, msiFiles := range d.MsiConfig[0].Files {
-				d.MsiConfig[0].Files[i] = path.Join("cmd", d.Name, msiFiles)
-			}
 		}).
 		withNightlyConfig().
 		build()


### PR DESCRIPTION
On #1235 I crossed some wires and committed changes that were supposed to come in the future  to add an MSI installer to the `opampsupervisor` binary distribution (spoilers). 

The change included the Go code to generate a goreleaser config for the `opampsupervisor` to build the MSI installer (you can see it being removed in the diff). Luckily I never regenerated the goreleaser configs with this, so nothing broke and there is nothing to change there as well.

This unintended change passed CI because our `ensure-goreleaser-up-to-date` make target was only checking distributions and not binaries. I updated it to check binaries and prevent this issue from happening again. 

