### PR TITLE
[distro/ebpf-profiler] Add OTLP receiver

### DIFF
--- a/.chloggen/ebpf-profiler-otlp-receiver.yaml
+++ b/.chloggen/ebpf-profiler-otlp-receiver.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: ebpf-profiler
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add the prometheus receiver to the ebpf-profiler distribution
+note: Add the otlp receiver to the ebpf-profiler distribution
 
 # One or more tracking issues or pull requests related to the change
 issues: [1343]

--- a/distributions/otelcol-ebpf-profiler/manifest.yaml
+++ b/distributions/otelcol-ebpf-profiler/manifest.yaml
@@ -27,7 +27,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.143.0
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.143.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.143.0
   - gomod: go.opentelemetry.io/ebpf-profiler v0.0.202601
     import: go.opentelemetry.io/ebpf-profiler/collector
 


### PR DESCRIPTION
This PR adds the OTLP Receiver to the `ebpf-profiler` distro. I would like to be able to use this receiver to monitor the Collector itself (internal telemetry), enrich it via the `resourcedetection` processor and re-export it via the OTLP exporter already present in the distro.