### PR TITLE
[chore] otelcol-ebpf-profiler: Drop CGO requirements

### DIFF
--- a/distributions/otelcol-ebpf-profiler/README.md
+++ b/distributions/otelcol-ebpf-profiler/README.md
@@ -10,18 +10,6 @@ Core](https://github.com/open-telemetry/opentelemetry-collector) and
 [OpenTelemetry Collector
 Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib).
 
-## Requirements
-
-### CGO
-
-The use of the foreign language interface to bring in dependencies requires to
-set CGO for the eBPF profiler.
-To utilize a foreign language interface for incorporating dependencies into the
-eBPF profiler, it is essential to configure and enable CGO.
-
-In order to enable CGO, we need a libc on the container.
-We use glibc, and the distribution is tested against v2.39.
-
 ## Components
 
 The full list of components is available in the [manifest](manifest.yaml).


### PR DESCRIPTION
The use of CGO was removed with https://github.com/open-telemetry/opentelemetry-collector-releases/commit/b2856164704d3efdb2195a2656198654320fb3a1. Update the README to reflect these changes.