### PR TITLE
Revert "fix(deps): update goreleaser pro to v2.14.0"

### DIFF
--- a/.github/workflows/base-binary-release.yaml
+++ b/.github/workflows/base-binary-release.yaml
@@ -24,7 +24,7 @@ on:
 
 env:
   # renovate: datasource=github-releases packageName=goreleaser/goreleaser-pro
-  GORELEASER_PRO_VERSION: v2.14.0
+  GORELEASER_PRO_VERSION: v2.13.3
 
 permissions:
   contents: read

--- a/.github/workflows/base-ci-binary.yaml
+++ b/.github/workflows/base-ci-binary.yaml
@@ -33,7 +33,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases packageName=goreleaser/goreleaser-pro
-  GORELEASER_PRO_VERSION: v2.14.0
+  GORELEASER_PRO_VERSION: v2.13.3
 
 jobs:
   check-goreleaser:

--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -37,7 +37,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases packageName=goreleaser/goreleaser-pro
-  GORELEASER_PRO_VERSION: v2.14.0
+  GORELEASER_PRO_VERSION: v2.13.3
 
 jobs:
   prev-tag:

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -26,7 +26,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases packageName=goreleaser/goreleaser-pro
-  GORELEASER_PRO_VERSION: v2.14.0
+  GORELEASER_PRO_VERSION: v2.13.3
 
 jobs:
   prev-tag:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-releases
 go 1.23
 
 require (
-	github.com/goreleaser/goreleaser-pro/v2 v2.14.0
+	github.com/goreleaser/goreleaser-pro/v2 v2.13.3
 	go.yaml.in/yaml/v3 v3.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/goreleaser/goreleaser-pro/v2 v2.13.3 h1:84IqC/ypQfPY4Y72LPhAtPfW//yaGv/H48w9BjCL65A=
 github.com/goreleaser/goreleaser-pro/v2 v2.13.3/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
-github.com/goreleaser/goreleaser-pro/v2 v2.14.0 h1:CBe2EapnxeMao1zChr4KuIm33Fr1YN7QX6Mjy6xj1cE=
-github.com/goreleaser/goreleaser-pro/v2 v2.14.0/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-releases#1385

breaks Docker build on Windows