### PR TITLE
[chore] Fix lychee config keys

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,11 +1,6 @@
-include-fragments = true
-
 accept = ["200..=299", "429"]
 
 exclude  = [
     "^http(s)?://localhost",
     "^http(s)?://example.com"
 ]
-
-# better to be safe and avoid failures
-max-retries = 6


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector/pull/14706

> The changelog link checker CI started failing after https://github.com/open-telemetry/opentelemetry-collector/pull/14676 bumped lycheeverse/lychee-action from v2.7.0 to v2.8.0, which bundles lychee v0.23.0.

> https://github.com/lycheeverse/lychee/pull/1906 made unknown TOML keys a hard error instead of silently ignoring them. The two keys in .github/lychee.toml used hyphens (include-fragments, max-retries), but the actual struct field names use underscores (include_fragments, max_retries).