### PR TITLE
[chore] add explicit telemetry configuration to config.yaml files

### DIFF
--- a/distributions/otelcol-contrib/config.yaml
+++ b/distributions/otelcol-contrib/config.yaml
@@ -55,6 +55,11 @@ service:
               prometheus:
                 host: '127.0.0.1'
                 port: 8888
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
+                with_resource_constant_labels:
+                  included: [ ]
 
   pipelines:
 

--- a/distributions/otelcol/config.yaml
+++ b/distributions/otelcol/config.yaml
@@ -55,6 +55,11 @@ service:
               prometheus:
                 host: '127.0.0.1'
                 port: 8888
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
+                with_resource_constant_labels:
+                  included: [ ]
 
   pipelines:
 


### PR DESCRIPTION
Expose explicitly the default telemetry settings in configuration.

This is a no-op change, since this matches the default configuration. It reduces user confusion as to where we bind to port 8888.