### PR TITLE
[wip] Add windows nightlies

### DIFF
--- a/.github/workflows/release-contrib.yaml
+++ b/.github/workflows/release-contrib.yaml
@@ -20,12 +20,12 @@ jobs:
     permissions: write-all
   release-windows:
     name: Release Contrib (Windows)
-    if: ${{ !contains(github.ref, '-nightly') }}
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol-contrib
       goos: '[ "windows" ]'
       goarch: '[ "386", "amd64", "arm64" ]'
       runner_os: windows-2022
+      nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-core.yaml
+++ b/.github/workflows/release-core.yaml
@@ -20,12 +20,12 @@ jobs:
     permissions: write-all
   release-windows:
     name: Release Core (Windows)
-    if: ${{ !contains(github.ref, '-nightly') }}
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol
       goos: '[ "windows" ]'
       goarch: '[ "386", "amd64", "arm64" ]'
       runner_os: windows-2022
+      nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-k8s.yaml
+++ b/.github/workflows/release-k8s.yaml
@@ -20,12 +20,12 @@ jobs:
     permissions: write-all
   release-windows:
     name: Release k8s (Windows)
-    if: ${{ !contains(github.ref, '-nightly') }}
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol-k8s
       goos: '[ "windows" ]'
       goarch: '[ "386", "amd64", "arm64" ]'
       runner_os: windows-2022
+      nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/.github/workflows/release-otlp.yaml
+++ b/.github/workflows/release-otlp.yaml
@@ -20,12 +20,12 @@ jobs:
     permissions: write-all
   release-windows:
     name: Release OTLP (Windows)
-    if: ${{ !contains(github.ref, '-nightly') }}
     uses: ./.github/workflows/base-release.yaml
     with:
       distribution: otelcol-otlp
       goos: '[ "windows" ]'
       goarch: '[ "386", "amd64", "arm64" ]'
       runner_os: windows-2022
+      nightly: ${{ contains(github.ref, '-nightly') }}
     secrets: inherit
     permissions: write-all

--- a/cmd/msi-generator/windows-installer.wxs.tmpl
+++ b/cmd/msi-generator/windows-installer.wxs.tmpl
@@ -4,7 +4,7 @@
       Name="OpenTelemetry Collector ({{ .Version }}) - {{ .Binary }} distribution"
       Id="*"
       UpgradeCode="B7C263DD-95A5-436A-A025-DCA5200C2BE3"
-      Version="{{ if .IsSnapshot }}{{ .RawVersion }}{{ else }}{{ .Version }}{{ end }}"
+      Version="{{ if .IsNightly }}{{ .RawVersion }}.{{ .Now.Format "00215" }}{{ else if .IsSnapshot }}{{ .RawVersion }}{{ else }}{{ .Version }}{{ end }}"
       Manufacturer="OpenTelemetry"
       Language="1033">
 

--- a/cmd/opampsupervisor/windows-installer.wxs
+++ b/cmd/opampsupervisor/windows-installer.wxs
@@ -3,7 +3,7 @@
       Name="OpenTelemetry OpAMP Supervisor ({{ .Version }})"
       Id="*"
       UpgradeCode="457B2070-3249-4092-A99E-EF8F7D2F5534"
-      Version="{{ if .IsSnapshot }}{{ .RawVersion }}{{ else }}{{ .Version }}{{ end }}"
+      Version="{{ if .IsNightly }}{{ .RawVersion }}.{{ .Now.Format "00215" }}{{ else if .IsSnapshot }}{{ .RawVersion }}{{ else }}{{ .Version }}{{ end }}"
       Manufacturer="OpenTelemetry"
       Language="1033">
 


### PR DESCRIPTION
This PR attempts to add Windows nightlies.

It was previously attempted but there were some failures because of strict versioning requirements on the `wxs` files. 

Here we try to set the nightly version to: `{{ .RawVersion }}.{{ .Now.Format "00215" }}`. 

According to https://pkg.go.dev/time, the time format `00215` will give us: zero-padded day of the year and hour in 24-hour format. This should be enough for the nightlies, as they run only once per day. 

This should close #1091.