### PR TITLE
[chore] add @dmathieu to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [Andrzej Stencel](https://github.com/andrzej-stencel), Elastic
 - [Antoine Toulme](https://github.com/atoulme), Splunk
 - [Bogdan Drutu](https://github.com/bogdandrutu), Snowflake
+- [Damien Mathieu](https://github.com/dmathieu), Elastic
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Evan Bradley](https://github.com/evan-bradley), Dynatrace
 - [Moritz Wiesinger](https://github.com/mowies), Dynatrace


### PR DESCRIPTION
As discussed in SIG on 3/25, @dmathieu is volunteering to help maintain collector releases and expand on the availability of the collector through homebrew.

This PR adds @dmathieu to the collector-releases maintainer team.