### PR TITLE
[chore] Add validation to push-tags Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,7 @@ goreleaser:
 REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git
 .PHONY: push-tags
 push-tags:
-	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
-	@echo "Adding tag ${TAG}"
-	@git tag -a ${TAG} -s -m "Version ${TAG}"
-	@echo "Pushing tag ${TAG}"
-	@git push ${REMOTE} ${TAG}
+	@./scripts/push-tag.sh
 
 # Used for debug only
 REMOTE?=git@github.com:open-telemetry/opentelemetry-collector-releases.git

--- a/scripts/push-tag.sh
+++ b/scripts/push-tag.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script creates and pushes the specified TAG to REMOTE
+
+set -euo pipefail
+
+if ! command -v yq &> /dev/null; then
+    echo "This script requires 'yq'. Please install and try again."
+    exit 1
+fi
+
+if [ -z "${TAG:-}" ]; then
+    echo "TAG must be set (e.g. TAG=v0.100.0)"
+    exit 1
+fi
+if [[ ! "${TAG}" =~ ^v.* ]]; then
+    echo "TAG must start with lowercase 'v' (e.g. v0.100.0)"
+    exit 1
+fi
+
+REMOTE="${REMOTE:-git@github.com:open-telemetry/opentelemetry-collector-releases.git}"
+VALIDATE="${VALIDATE:-true}"
+VERSION="${TAG#v}"
+
+if [ "${VALIDATE}" = "true" ]; then
+    for dir in distributions/*/; do
+        manifest="${dir}manifest.yaml"
+        if [ -f "${manifest}" ]; then
+            dist_version=$(yq '.dist.version' "${manifest}")
+            if [ "${dist_version}" != "${VERSION}" ]; then
+                echo "Version mismatch in ${manifest}: dist.version is set to '${dist_version}', expected '${VERSION}'"
+                echo "Please ensure the '[chore] Prepare release ${VERSION}' PR has been merged."
+                echo "If this version mismatch is expected, please re-run with the extra argument 'VALIDATE=false'"
+                exit 1
+            fi
+        fi
+    done
+fi
+
+echo "Adding tag ${TAG}"
+git tag -a ${TAG} -s -m "Version ${TAG}"
+echo "Pushing tag ${TAG}"
+git push ${REMOTE} ${TAG}

--- a/scripts/push-tag.sh
+++ b/scripts/push-tag.sh
@@ -41,6 +41,6 @@ if [ "${VALIDATE}" = "true" ]; then
 fi
 
 echo "Adding tag ${TAG}"
-git tag -a ${TAG} -s -m "Version ${TAG}"
+git tag -a "${TAG}" -s -m "Version ${TAG}"
 echo "Pushing tag ${TAG}"
-git push ${REMOTE} ${TAG}
+git push "${REMOTE}" "${TAG}"


### PR DESCRIPTION
**Description:**
When releasing `v0.150.0`, I misread [directions](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/docs/release.md#releasing-opentelemetry-collector-releases) and didn't understand steps 1 and 2 were two different PRs. This resulted in needing to create a patch release `v0.150.1` to address the incorrect contents of the `v0.150.0` tag.

This PR moves the functionality of creating and pushing a tag to a standalone script and validates that the manifests have been properly updated by the `[chore] Prepare release` PR.

**Testing:**
```
$ make push-tags
TAG must be set (e.g. TAG=v0.100.0)
make: *** [push-tags] Error 1

$ make push-tags TAG=0.151.0
TAG must start with lowercase 'v' (e.g. v0.100.0)
make: *** [push-tags] Error 1

$ make push-tags TAG=v0.151.0
Version mismatch in distributions/otelcol-contrib/manifest.yaml: dist.version is set to '0.150.1', expected '0.151.0'
Please ensure the '[chore] Prepare release 0.151.0' PR has been merged.
If this version mismatch is expected, please re-run with the extra argument 'VALIDATE=false'
make: *** [push-tags] Error 1

$ make push-tags TAG=v0.150.1
Adding tag v0.150.1
Pushing tag v0.150.1

$ make push-tags TAG=v0.151.0 VALIDATE=false
Adding tag v0.151.0
Pushing tag v0.151.0
```

_Disclosure: I used Codex and Claude to generate most of this script._