### PR TITLE
[chore] fix broken pipe errors in CI pipeline

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -98,6 +98,11 @@ jobs:
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
 
+      - name: Start Docker daemon (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Start-Service docker
+
       - name: Setup wixl # Required to build MSI packages for Windows
         if: runner.os != 'Windows'
         run: |
@@ -322,6 +327,11 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
+
+      - name: Start Docker daemon (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Start-Service docker
 
       - name: Download container image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -98,11 +98,6 @@ jobs:
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
 
-      - name: Start Docker daemon (Windows)
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: Start-Service docker
-
       - name: Setup wixl # Required to build MSI packages for Windows
         if: runner.os != 'Windows'
         run: |
@@ -327,11 +322,6 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
-
-      - name: Start Docker daemon (Windows)
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: Start-Service docker
 
       - name: Download container image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/scripts/validate-components.sh
+++ b/scripts/validate-components.sh
@@ -97,7 +97,7 @@ while IFS= read -r manifest_file; do
 
   # Compare each manifest component against the valid list
   while IFS= read -r component; do
-    if ! printf '%s\n' "$valid_components" | grep -qxF "$component"; then
+    if ! grep -qxF "$component" <<< "$valid_components"; then
       invalid_components="${invalid_components}\n${component}"
     fi
   done <<< "$manifest_components"


### PR DESCRIPTION
**Fix intermittent CI failures caused by broken pipe in `validate-components.sh`**

`printf '%s\n' "$valid_components" | grep -qxF "$component"` was intermittently failing under `set -o pipefail`. When `grep -q` finds a match it exits early, closing the pipe while `printf` is still writing — causing `printf` to receive `SIGPIPE` (exit 141). With `pipefail`, the pipeline returns 141 (non-zero), and the surrounding `if !` negates it to _true_, incorrectly treating valid components as missing and failing the build.

Fixed by replacing the pipe with a here-string (`<<< "$valid_components"`), which passes the data directly to grep with no pipe involved.

**Example failing runs:**
- https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/24708467235
- https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/24699008332
- https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/24698836287

This was implemented using Claude Code.