### PR TITLE
[chore] explicitly start Docker daemon on Windows runners

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -98,6 +98,11 @@ jobs:
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
 
+      - name: Start Docker daemon (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Start-Service docker
+
       - name: Setup wixl # Required to build MSI packages for Windows
         if: runner.os != 'Windows'
         run: |
@@ -322,6 +327,11 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: arm64,ppc64le,linux/arm/v7,s390x,riscv64
+
+      - name: Start Docker daemon (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Start-Service docker
 
       - name: Download container image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Some Windows-2022 GitHub Actions VM instances don't have the Docker daemon running by default, causing intermittent failures in both check-goreleaser (GoReleaser docker build) and docker-tests (docker image load). Both jobs now explicitly call Start-Service docker before any Docker operations.

This was implemented using Claude Code.