### PR TITLE
[k8s] add drain processor

### DIFF
--- a/.chloggen/add_drain_processor_k8s.yaml
+++ b/.chloggen/add_drain_processor_k8s.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: drainprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add drain processor to k8s distribution.
+
+# One or more tracking issues or pull requests related to the change
+issues: [47235]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/distributions/otelcol-k8s/manifest.yaml
+++ b/distributions/otelcol-k8s/manifest.yaml
@@ -40,6 +40,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.151.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.151.0


### PR DESCRIPTION
Add the drain processor to the k8s distribution.

The logdedup processor is already in the k8s distro and pairs naturally with drain — drain derives log templates (e.g. `"user <*> logged in from <*>"`) that logdedup can use to deduplicate log records. Including both in the k8s distro enables this combination out of the box for Kubernetes users.

Contrib PR: open-telemetry/opentelemetry-collector-contrib#48077
Tracking issue: open-telemetry/opentelemetry-collector-contrib#47235