### PR TITLE
[chore] Add genainormalizerprocessor to otelcol-contrib distribution

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -108,6 +108,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.153.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/genainormalizerprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.153.0


### PR DESCRIPTION
#### Description

Adds `processor/genainormalizerprocessor` to the `otelcol-contrib` distribution manifest. Companion to open-telemetry/opentelemetry-collector-contrib#48773 (alpha promotion).

#### Link to tracking issue

- related to open-telemetry/opentelemetry-collector-contrib#46069.
