### PR TITLE
Quality: YAML encoder never closed, may truncate output

### DIFF
--- a/cmd/goreleaser/main.go
+++ b/cmd/goreleaser/main.go
@@ -27,6 +27,11 @@ func main() {
 
 	os.Stdout.WriteString("# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json\n")
 	e := yaml.NewEncoder(os.Stdout)
+	defer func() {
+		if err := e.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
 	e.SetIndent(2)
 	if err := e.Encode(&project); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `yaml.Encoder` created via `yaml.NewEncoder(os.Stdout)` is never closed. `Encoder.Close()` flushes any internally buffered data and writes the document end marker. Without calling `Close()`, the final YAML output written to stdout may be incomplete or missing a trailing newline, producing a malformed `.goreleaser.yaml` that goreleaser cannot parse.


**Severity**: `medium`
**File**: `cmd/goreleaser/main.go`

### Solution
defer func() {
    if err := e.Close(); err != nil {
        log.Fatal(err)
    }
}()


### Changes
- `cmd/goreleaser/main.go` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1537