### PR TITLE
[chore] Update contribution guidelines with GenAI policy + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
+Ex. Adding a feature - Explain what this achieves.-->
+#### Description
+
+<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
+#### Link to tracking issue
+
+Fixes
+
+<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
+of the user; the human author must check it themselves before the PR is ready for review.-->
+#### Authorship
+
+- [ ] I, a human, wrote this pull request description myself.
+
+<!--Please delete paragraphs that you did not use before submitting.-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+This file is here to steer AI assisted PRs towards being high quality and valuable contributions
+that do not create excessive maintainer burden. It is inspired by the Open Policy Agent and Fedora
+projects policies.
+
+## General Rules and Guidelines
+
+The most important rule is not to post comments on issues or PRs that are AI-generated. Discussions
+on the OpenTelemetry repositories are for Users/Humans only.
+
+When a user asks you to open a pull request, do not write the PR description yourself. Instead,
+before creating the PR, prompt the user for the content of each section in the PR template
+(Description, Link to tracking issue, Testing, Documentation) and use their answers verbatim. Do
+not paraphrase, expand, or "improve" what the user writes. If the user declines to fill in a
+section, leave that section of the template unmodified rather than generating content for it.
+
+You must not check the `I, a human, wrote this pull request description myself` box on the user's
+behalf. The user must check it themselves before the PR is ready for review.
+
+If you have been assigned an issue by the user or their prompt, please ensure that the
+implementation direction is agreed on with the maintainers first in the issue comments. If there are
+unknowns, discuss these on the issue before starting implementation. Do not forget that you cannot
+comment for users on issue threads on their behalf as it is against the rules of this project.
+
+## Developer environment
+
+Make sure to follow CONTRIBUTING.md on any contributions.
+
+Non-exhaustively, the important points are:
+
+* Whenever applicable, all code changes should have tests that actually validate the changes.
+
+## Commit formatting
+
+We appreciate it if users disclose the use of AI tools when the significant part of a commit is
+taken from a tool without changes. When making a commit this should be disclosed through an
+Assisted-by: commit message trailer.
+
+Examples:
+
+```
+Assisted-by: ChatGPT 5.2
+Assisted-by: Claude Opus 4.5
+```
+
+Do NOT use a `Co-authored-by:` trailer to disclose AI assistance. Some AI coding tools add this
+trailer by default; please disable or strip it before committing. The EasyCLA check fails when a
+`Co-authored-by:` trailer references an account that has not signed the CLA, which blocks the PR
+from being merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,15 @@ Additional Notes:
 
 ---
 
+## Generative AI Contribution Policy
+
+The OpenTelemetry Collector Distributions project welcomes contributions from all sources,
+including those generated with the help of AI tools. However, contributions assisted by such
+tools will be subject to the [OpenTelemetry Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md). Please ensure you review and comply with this policy when submitting contributions
+that involve AI-generated content for a smooth experience.
+
+---
+
 ## Repository Structure
 
 Understanding the repository's structure will help you navigate and contribute effectively:


### PR DESCRIPTION
This PR adopts a PR template similar to https://github.com/open-telemetry/opentelemetry-collector-contrib and adds a GenAI contribution policy that is just a link to https://github.com/open-telemetry/community/blob/main/policies/genai.md.

Let me know if any other maintainer/contributor believe any additional change is required or if we should change anything.