### PR TITLE
Update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_COLLECTOR_RELEASES_APP_ID }}
+          client-id: ${{ vars.OTELBOT_COLLECTOR_RELEASES_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_COLLECTOR_RELEASES_PRIVATE_KEY }}
           permission-contents: write
 

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_COLLECTOR_RELEASES_APP_ID }}
+          client-id: ${{ vars.OTELBOT_COLLECTOR_RELEASES_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_COLLECTOR_RELEASES_PRIVATE_KEY }}
 
       - name: Set up commit author name and email


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The `app-id` input for `actions/create-github-app-token` is deprecated in favor of `client-id`. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id` / `*_APP_ID` to `client-id` / `*_CLIENT_ID`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744