### PR TITLE
chore(contrib): pin ebpf version to v0.21.0

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -273,3 +273,4 @@ providers:
 replaces:
   # Prepared by scripts/prepare-obi.sh from a tagged upstream source archive.
   - go.opentelemetry.io/obi => ../../../internal/obi-src
+  - github.com/cilium/ebpf => github.com/cilium/ebpf v0.21.0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This pin needed to happen because of a version incompatiblity between OBI and eBPF v0.22.0.
OBI ships with eBPF v0.20.0 and is not compatible with v0.22.0. Collector contrib has eBPF v0.22.0 as a transitive dependency and so during building, Go decides to use the higher version of the 2 which results in build error that can be see [here](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/29881624893/job/88854526021?pr=1566).

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
