### PR TITLE
[chore][govuln] Replace vulnerable github.com/hamba/avro/v2 with maintained fork

### DIFF
--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -274,3 +274,5 @@ replaces:
   # Prepared by scripts/prepare-obi.sh from a tagged upstream source archive.
   - go.opentelemetry.io/obi => ../../../internal/obi-src
   - github.com/cilium/ebpf => github.com/cilium/ebpf v0.21.0
+  # github.com/hamba/avro/v2 is no longer maintained and has vulnerabilities
+  - github.com/hamba/avro/v2 => github.com/iskorotkov/avro/v2 v2.33.0


### PR DESCRIPTION
#### Description
Replace vulnerable github.com/hamba/avro/v2 (no longer maintained) with maintained fork to fix a few Go vulns, e.g. https://pkg.go.dev/vuln/GO-2026-5046

Counterpart in contrib: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49918
