### PR TITLE
Update signing config to work with cosign v3

### DIFF
--- a/.chloggen/migrate_sigstore_bundles.yaml
+++ b/.chloggen/migrate_sigstore_bundles.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: release
+component: all
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Update Cosign usage to work with v3
@@ -18,8 +18,11 @@ issues: [1570]
 subtext: |
   The Cosign v3 upgrade introduced a change in signing workflow. Previous two files
   were required to map the outputs (certificate and signature), now only one file is required.
-  This file is a bundle that contains both outputs in JSON format.
+  The new file is a bundle that contains both outputs in JSON format.
   This change has been done following the guidance from https://goreleaser.com/blog/cosign-v3/.
+  With this change, anyone who wants to verify the signature of the artifacts produced by the
+  release will need to use Cosign V3 and point to the new bundle file or download the bundle and
+  unpack it to get the certificate and signature files.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/.chloggen/migrate_sigstore_bundles.yaml
+++ b/.chloggen/migrate_sigstore_bundles.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: release
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update Cosign usage to work with v3
+
+# One or more tracking issues or pull requests related to the change
+issues: [1570]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Cosign v3 upgrade introduced a change in signing workflow. Previous two files
+  were required to map the outputs (certificate and signature), now only one file is required.
+  This file is a bundle that contains both outputs in JSON format.
+  This change has been done following the guidance from https://goreleaser.com/blog/cosign-v3/.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/.goreleaser.yaml
+++ b/cmd/builder/.goreleaser.yaml
@@ -62,14 +62,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign

--- a/cmd/goreleaser/internal/builder.go
+++ b/cmd/goreleaser/internal/builder.go
@@ -278,16 +278,12 @@ func (b *distributionBuilder) withDefaultSigns() *distributionBuilder {
 func (b *distributionBuilder) signs() []config.Sign {
 	return []config.Sign{
 		{
-			Artifacts:   "all",
-			Signature:   "${artifact}.sig",
-			Certificate: "${artifact}.pem",
-			Cmd:         "cosign",
+			Artifacts: "all",
+			Signature: "${artifact}.sigstore.json",
+			Cmd:       "cosign",
 			Args: []string{
 				"sign-blob",
-				"--output-signature",
-				"${artifact}.sig",
-				"--output-certificate",
-				"${artifact}.pem",
+				"--bundle=${signature}",
 				"${artifact}",
 			},
 		},

--- a/cmd/opampsupervisor/.goreleaser.yaml
+++ b/cmd/opampsupervisor/.goreleaser.yaml
@@ -98,14 +98,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -135,14 +135,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign

--- a/distributions/otelcol-ebpf-profiler/.goreleaser.yaml
+++ b/distributions/otelcol-ebpf-profiler/.goreleaser.yaml
@@ -38,14 +38,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -53,14 +53,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -123,14 +123,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -127,14 +127,10 @@ signs:
   - cmd: cosign
     args:
       - sign-blob
-      - --output-signature
-      - ${artifact}.sig
-      - --output-certificate
-      - ${artifact}.pem
+      - --bundle=${signature}
       - ${artifact}
-    signature: ${artifact}.sig
+    signature: ${artifact}.sigstore.json
     artifacts: all
-    certificate: ${artifact}.pem
 docker_signs:
   - args:
       - sign


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Since https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1574 upgraded the Cosign action to the v3 major version, nightlies started to fail due to some breaking changes in the signing workflow.

Previous two files were required to map the outputs (certificate and signature), now only one file is required. This file is a bundle that contains both outputs in JSON format. This change has been done following the guidance from https://goreleaser.com/blog/cosign-v3/.

With this change, anyone who wants to verify the signature of the artifacts produced by the release will need to use Cosign V3 and point to the new bundle file or download the bundle and unpack it to get the certificate and signature files.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #1570.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
