### PR TITLE
Skip trying to publish docker manifests from AIX build

### DIFF
--- a/.chloggen/skip_docker_builds_for_aix.yaml
+++ b/.chloggen/skip_docker_builds_for_aix.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: contrib
+component: all
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Skip Docker build and publish in AIX release job.

--- a/.chloggen/skip_docker_builds_for_aix.yaml
+++ b/.chloggen/skip_docker_builds_for_aix.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: contrib
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip Docker build and publish in AIX release job.
+
+# One or more tracking issues or pull requests related to the change
+issues: [1580]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The release for Contrib on AIX runs in its own job, where it doesn't build
+  Docker images. The `continue --merge` phase of goreleaser runs all publishers
+  by default, including the Docker manifests one. This will fail for AIX as
+  the images aren't built.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: false
+      skips:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -108,6 +112,12 @@ jobs:
         run: |
           echo "NIGHTLY_FLAG=--nightly" >> "$GITHUB_OUTPUT"
 
+      - name: Set skips flag
+        id: skips-check
+        if: inputs.skips != ''
+        run: |
+          echo "SKIPS_FLAG=--skip=${{ inputs.skips }}" >> "$GITHUB_OUTPUT"
+
       - name: Fetch OBI source
         if: inputs.distribution == 'otelcol-contrib'
         uses: ./.github/actions/fetch-obi
@@ -143,7 +153,7 @@ jobs:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
           workdir: distributions/${{ inputs.distribution }}
-          args: release --clean --split --timeout 2h --config .goreleaser-build.yaml --release-header-tmpl=../../.github/release-template.md ${{ steps.nightly-check.outputs.NIGHTLY_FLAG }}
+          args: release --clean --split --timeout 2h --config .goreleaser-build.yaml --release-header-tmpl=../../.github/release-template.md ${{ steps.nightly-check.outputs.NIGHTLY_FLAG }} ${{ steps.skips-check.outputs.SKIPS_FLAG }}
         env:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
@@ -170,7 +180,7 @@ jobs:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
           workdir: distributions/${{ inputs.distribution }}
-          args: release --clean --split --timeout 2h --release-header-tmpl=../../.github/release-template.md ${{ steps.nightly-check.outputs.NIGHTLY_FLAG }}
+          args: release --clean --split --timeout 2h --release-header-tmpl=../../.github/release-template.md ${{ steps.nightly-check.outputs.NIGHTLY_FLAG }} ${{ steps.skips-check.outputs.SKIPS_FLAG }}
         env:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}

--- a/.github/workflows/release-contrib.yaml
+++ b/.github/workflows/release-contrib.yaml
@@ -26,6 +26,7 @@ jobs:
       goos: '[ "aix" ]'
       goarch: '[ "ppc64" ]'
       nightly: ${{ contains(github.ref, '-nightly') }}
+      skips: 'docker'
     secrets: inherit
     permissions: write-all
   release-windows:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The AIX build job was trying to publish Docker manifests for the supported linux (os, arch) tuples, which are not built in the AIX job. 

A simple `skip_push`/`skip_build` in the Docker manifests doesn't work because `.Runtime.GOOS` is the GOOS of the compiled `goreleaser` binary (it will be `linux`). 

So I decide to add an option to the base release job that maps to the `--skip` option of GoReleaser, allowing us to skip Docker manifests building/publishing. 


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #1580.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
