### PR TITLE
Use split checksum filename template to avoid overwrites

### DIFF
--- a/.chloggen/use_split_checksum.yaml
+++ b/.chloggen/use_split_checksum.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use split checksum for all binaries and distros
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The previous attempt at splitting the checksum file for AIX releases was not successful.
+  The problem lies on the fac that `.runtime.GOOS` will always be the runtime of the compiled
+  goreleaser binary ("linux" in this case). The only way to split the checksum file per target
+  is what's implement here, but it ends up giving one checksum file per produced artifact.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/use_split_checksum.yaml
+++ b/.chloggen/use_split_checksum.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: all

--- a/.chloggen/use_split_checksum.yaml
+++ b/.chloggen/use_split_checksum.yaml
@@ -10,7 +10,7 @@ component: all
 note: Use split checksum for all binaries and distros
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [1582]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/builder/.goreleaser.yaml
+++ b/cmd/builder/.goreleaser.yaml
@@ -55,7 +55,7 @@ archives:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: checksums.txt
+  split: true
 changelog:
   disable: "true"
 signs:

--- a/cmd/goreleaser/internal/builder.go
+++ b/cmd/goreleaser/internal/builder.go
@@ -354,7 +354,7 @@ func (b *distributionBuilder) newSboms() []config.SBOM {
 func (b *distributionBuilder) withDefaultChecksum() *distributionBuilder {
 	b.configFuncs = append(b.configFuncs, func(d *distribution) {
 		b.dist.Checksum = config.Checksum{
-			NameTemplate: fmt.Sprintf("{{ .ProjectName }}_%v{{ if in (list \"windows\" \"aix\") .Runtime.Goos }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt", d.Name),
+			Split: true,
 		}
 	})
 	return b
@@ -363,7 +363,7 @@ func (b *distributionBuilder) withDefaultChecksum() *distributionBuilder {
 func (b *distributionBuilder) withDefaultBinaryChecksum() *distributionBuilder {
 	b.configFuncs = append(b.configFuncs, func(d *distribution) {
 		b.dist.Checksum = config.Checksum{
-			NameTemplate: "checksums.txt",
+			Split: true,
 		}
 	})
 	return b

--- a/cmd/opampsupervisor/.goreleaser.yaml
+++ b/cmd/opampsupervisor/.goreleaser.yaml
@@ -91,7 +91,7 @@ nfpms:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: checksums.txt
+  split: true
 changelog:
   disable: "true"
 signs:

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -130,7 +130,7 @@ nfpms:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: '{{ .ProjectName }}_otelcol-contrib{{ if in (list "windows" "aix") .Runtime.Goos }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
+  split: true
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-ebpf-profiler/.goreleaser.yaml
+++ b/distributions/otelcol-ebpf-profiler/.goreleaser.yaml
@@ -33,7 +33,7 @@ archives:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: '{{ .ProjectName }}_otelcol-ebpf-profiler{{ if in (list "windows" "aix") .Runtime.Goos }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
+  split: true
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -48,7 +48,7 @@ archives:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: '{{ .ProjectName }}_otelcol-k8s{{ if in (list "windows" "aix") .Runtime.Goos }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
+  split: true
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -118,7 +118,7 @@ nfpms:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: '{{ .ProjectName }}_otelcol-otlp{{ if in (list "windows" "aix") .Runtime.Goos }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
+  split: true
 signs:
   - cmd: cosign
     args:

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -122,7 +122,7 @@ nfpms:
 snapshot:
   version_template: '{{ incpatch .Version }}-next'
 checksum:
-  name_template: '{{ .ProjectName }}_otelcol{{ if in (list "windows" "aix") .Runtime.Goos }}_{{ .Runtime.Goos }}{{ end }}_checksums.txt'
+  split: true
 signs:
   - cmd: cosign
     args:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The previous attempt at splitting the checksum file for AIX releases was not successful. The problem lies on the fac that `.runtime.GOOS` will always be the runtime of the compiled goreleaser binary ("linux" in this case). The only way to split the checksum file per target is what's implement here, but it ends up giving one checksum file per produced artifact.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
