### PR TITLE
chore: remove need to provide release tag manually

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -12,7 +12,7 @@ For general information about all Collector repositories release procedures, see
    opentelemetry-collector and opentelemetry-collector-contrib version have been released. The opentelemetry-collector-releases release
    should be done after both of these releases.
 1. Review and merge the Renovate PR for core and contrib components, including OCB. If they were not created or updated yet, you can go to the **Dependency Dashboard** GitHub issue and check the boxes for the updates or for a manual Renovate run to expedite the process.
-2. Run the GitHub Action workflow "[Update Version in Distributions and Prepare PR](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/workflows/update-version.yaml)" which will update the minor version automatically (e.g. v0.116.0 -> v0.117.0) or manually provide a new version if releasing a bugfix or skipping a version. Select "create pr" option.
+2. Run the GitHub Action workflow "[Update Version in Distributions and Prepare PR](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/workflows/update-version.yaml)" which will update the minor version automatically (e.g. v0.116.0 -> v0.117.0). Select "create pr" option.
 The PR needs to be manually closed and re-opened once to trigger pipelines.
    -  🛑 **Do not move forward until both the Renovate and '[chore] Prepare release...' PRs are merged.** 🛑
 3. Check out main and ensure it has the "Update version from ..." commit in your local
@@ -24,7 +24,7 @@ The PR needs to be manually closed and re-opened once to trigger pipelines.
    
    ⚠️ If you set your remote using `https` you need to include `REMOTE=https://github.com/open-telemetry/opentelemetry-collector-releases.git` in each command. ⚠️
    
-   - `make push-tags TAG=v0.85.0`
+   - `make push-tags`
 5. Wait for the new tag build to pass successfully.
 6. Ensure the "Release Core", "Release Contrib", "Release k8s", "Release OTLP", "Release Builder" and "Release OpAMP Supervisor" actions pass, this will
     1. push new container images to `https://hub.docker.com/repository/docker/otel/opentelemetry-collector`, `https://hub.docker.com/repository/docker/otel/opentelemetry-collector-contrib` and `https://hub.docker.com/repository/docker/otel/opentelemetry-collector-k8s` as well as their respective counterparts on GHCR

--- a/scripts/push-tag.sh
+++ b/scripts/push-tag.sh
@@ -13,8 +13,8 @@ if ! command -v yq &> /dev/null; then
 fi
 
 if [ -z "${TAG:-}" ]; then
-    echo "TAG must be set (e.g. TAG=v0.100.0)"
-    exit 1
+    TAG="v$(yq '.dist.version' distributions/otelcol/manifest.yaml)"
+    echo "TAG not set, inferred from distributions/otelcol/manifest.yaml: ${TAG}"
 fi
 if [[ ! "${TAG}" =~ ^v.* ]]; then
     echo "TAG must start with lowercase 'v' (e.g. v0.100.0)"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR removes the need to specify the release tag manually, but keeps the possibility to still define it when needed.
It infers the release version from the otelcol distro manifest.yaml file. The `push-tag.sh` script already checks if the specified tag is the correct one to release for all distros so inferring from just one distro is fine.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #879

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
