### PR TITLE
Make binary release tag-push idempotent to allow retries

### DIFF
--- a/.github/workflows/base-binary-release.yaml
+++ b/.github/workflows/base-binary-release.yaml
@@ -59,8 +59,12 @@ jobs:
           message="Releasing ${{ inputs.binary }} binaries for ${{ steps.collector-ref.outputs.COLLECTOR_REF }}"
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -a "${tag}" -m "${message}"
-          git push origin "${tag}"
+          if git ls-remote --exit-code --tags origin "${tag}" > /dev/null; then
+            echo "Tag ${tag} already exists on origin, skipping creation (this is a retry)"
+          else
+            git tag -a "${tag}" -m "${message}"
+            git push origin "${tag}"
+          fi
 
       - name: Set goreleaser last tag reference in case of non-nightly release
         id: prev-tag


### PR DESCRIPTION
#### Description
Skip creating tag in release CI if it already exists so that CI can be retried. 

Right now we need to manually delete the tag from remote before retrying it

#### Link to tracking issue

Fixes #1610

#### Authorship

- [x] I, a human, wrote this pull request description myself.
