### PR TITLE
chore: prevent apt-get hangs during wixl installation

### DIFF
--- a/.github/workflows/base-binary-release.yaml
+++ b/.github/workflows/base-binary-release.yaml
@@ -119,9 +119,11 @@ jobs:
 
       - name: Setup wixl # Required to build MSI packages for Windows
         if: inputs.windows-msi == true && runner.os != 'Windows'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wixl
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo apt-get update && sudo apt-get install -y wixl
 
       - name: Log into Docker.io
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/base-ci-binary.yaml
+++ b/.github/workflows/base-ci-binary.yaml
@@ -79,9 +79,11 @@ jobs:
 
       - name: Setup wixl # Required to build MSI packages for Windows
         if: inputs.windows-msi == true && runner.os != 'Windows'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wixl
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo apt-get update && sudo apt-get install -y wixl
 
       - name: Check GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -103,12 +103,6 @@ jobs:
         shell: powershell
         run: Start-Service docker
 
-      - name: Setup wixl # Required to build MSI packages for Windows
-        if: runner.os != 'Windows'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wixl
-
       - name: Setup Docker Buildx
         if: runner.os != 'Windows'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR fixes some pipeline hangs where the wixl installation steps hung for hours. This should be fixed by the retry-action which has a timeout and retry count.
Additionally, the wixl installation step is not needed at all in `base-ci-goreleaser.yaml` since it's only necessary on non-windows OSes that need to build MSI installers. We don't have this case anymore since the change to using native windows runners for all windows builds. Those runners already come with the WiX toolkit installed, so no wixl needed there.

Examples of pipeline runs that hung for a long time:
https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/32233776421/job/96009585114
https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/26431746826/job/77806216792
https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/32233776404/job/96009498437
https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/32233776421/job/96009585235


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
