### PR TITLE
chore: fix token permission issues

### DIFF
--- a/.github/workflows/cleanup-nightly.yaml
+++ b/.github/workflows/cleanup-nightly.yaml
@@ -24,11 +24,14 @@ jobs:
   cleanup-nightly:
     name: Cleanup Old Nightly Releases
     runs-on: ubuntu-latest
-    # Deletions are authenticated with the otelbot app token (see permission-contents
-    # and permission-packages below), not with GITHUB_TOKEN, so GITHUB_TOKEN itself
-    # needs nothing beyond the read-only default.
+    # Git tag deletion uses the otelbot app token (permission-contents below).
+    # Container package deletion uses GITHUB_TOKEN instead, matching how the release
+    # workflows authenticate against GHCR: the otelbot app installation is not granted
+    # the packages permission, and requesting it makes the token request fail with
+    # "The permissions requested are not granted to this installation".
     permissions:
       contents: read
+      packages: write # required to delete GHCR package versions
     defaults:
       run:
         shell: bash
@@ -54,7 +57,6 @@ jobs:
           client-id: ${{ vars.OTELBOT_COLLECTOR_RELEASES_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_COLLECTOR_RELEASES_PRIVATE_KEY }}
           permission-contents: write
-          permission-packages: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -66,7 +68,7 @@ jobs:
 
       - name: Delete nightly GHCR package versions older than 2 weeks
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG: open-telemetry
           GHCR_REPO: opentelemetry-collector-releases
         run: ./.github/workflows/scripts/cleanup-nightly-ghcr.sh

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -46,8 +46,10 @@ jobs:
     needs: nightly-release
     uses: ./.github/workflows/cleanup-nightly.yaml
     secrets: inherit
-    # Caps the GITHUB_TOKEN handed to the called workflow. It deletes via the otelbot
-    # app token instead, so read-only is enough.
+    # Caps the GITHUB_TOKEN handed to the called workflow. Git tags are deleted with the
+    # otelbot app token, but GHCR package deletion uses GITHUB_TOKEN, so packages: write
+    # has to be granted here as well or it is capped away from the called workflow.
     permissions:
       contents: read
+      packages: write
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR tries to fix token permission issues that came up in the nightly tag delete github workflow. (see [this run](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/32263539361))
Github token permissions are changed to follow the pattern of other pipelines and prevent failures due to permission issues.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Follow up to: https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1406

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
