### PR TITLE
Remove stale cilium/ebpf dependency override

### DIFF
--- a/.chloggen/remove-obi-ebpf-override.yaml
+++ b/.chloggen/remove-obi-ebpf-override.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: otelcol-contrib
+note: Remove the obsolete cilium/ebpf v0.21.0 override so OBI v0.11.0 builds with v0.22.0.
+issues: [1604]
+subtext:
+change_logs: [user]

--- a/.chloggen/remove-obi-ebpf-override.yaml
+++ b/.chloggen/remove-obi-ebpf-override.yaml
@@ -1,6 +1,6 @@
-change_type: bug_fix
+change_type: enhancement
 component: otelcol-contrib
-note: Remove the obsolete cilium/ebpf v0.21.0 override so OBI v0.11.0 builds with v0.22.0.
+note: Upgrade go.opentelemetry.io/obi to v0.11.0.
 issues: [1604]
 subtext:
 change_logs: [user]

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -137,7 +137,7 @@ receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.159.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.159.0
   # OBI (eBPF Instrumentation)
-  - gomod: go.opentelemetry.io/obi v0.10.0
+  - gomod: go.opentelemetry.io/obi v0.11.0
     import: go.opentelemetry.io/obi/collector
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.159.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.159.0

--- a/distributions/otelcol-contrib/manifest.yaml
+++ b/distributions/otelcol-contrib/manifest.yaml
@@ -274,6 +274,5 @@ providers:
 replaces:
   # Prepared by scripts/prepare-obi.sh from a tagged upstream source archive.
   - go.opentelemetry.io/obi => ../../../internal/obi-src
-  - github.com/cilium/ebpf => github.com/cilium/ebpf v0.21.0
   # github.com/hamba/avro/v2 is no longer maintained and has vulnerabilities
   - github.com/hamba/avro/v2 => github.com/iskorotkov/avro/v2 v2.33.0


### PR DESCRIPTION
#### Description

Remove the temporary `github.com/cilium/ebpf v0.21.0` replacement from the `otelcol-contrib` manifest while retaining the local OBI source replacement.

OBI v0.11.0 requires cilium/ebpf v0.22.0 and uses the `CollectionOptions.Cache` API introduced in that version. The stale override forces v0.21.0 and causes the collector build to fail because that API is not available. Without the override, Go resolves cilium/ebpf v0.22.0 and OBI v0.11.0 compiles successfully.

#### Link to tracking issue

Supersedes #1604

#### Authorship

- [x] I, a human, wrote this pull request description myself.