### PR TITLE
[chore] bump go versions to 1.26.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-releases
 
-go 1.23
+go 1.26.0
 
 require (
 	github.com/goreleaser/goreleaser-pro/v2 v2.17.1

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,4 @@
-github.com/goreleaser/goreleaser-pro/v2 v2.15.4 h1:RIsYZG8Wj7l1yjUEw5p58BpBtgMjiVvaTL3nwXvX9Yw=
-github.com/goreleaser/goreleaser-pro/v2 v2.15.4/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
-github.com/goreleaser/goreleaser-pro/v2 v2.16.0 h1:vEFa69xE1onDdpt/34ttTIOQGGnGwge1BFrbVQHZJnE=
-github.com/goreleaser/goreleaser-pro/v2 v2.16.0/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
-github.com/goreleaser/goreleaser-pro/v2 v2.17.0 h1:ns3VncXLYFRi8bkQs2ypaGhM94kYoDIlm4X1kM27oFw=
-github.com/goreleaser/goreleaser-pro/v2 v2.17.0/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
 github.com/goreleaser/goreleaser-pro/v2 v2.17.1 h1:Vsa0b6r6+x/jiq6c45RKyI0amPnZDa2OOizoZh9Zcs8=
 github.com/goreleaser/goreleaser-pro/v2 v2.17.1/go.mod h1:GA7Uzk7qKA3efeDmgfWwcMTrDJe+V7D6H5RMqXlFvuc=
-go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.25.0
+go 1.26.0
 
 require go.opentelemetry.io/build-tools/chloggen v0.30.0
 

--- a/tests/msi/go.mod
+++ b/tests/msi/go.mod
@@ -1,6 +1,6 @@
 module msi
 
-go 1.23
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
#### Description
Bump go in go.mod up to 1.26.0

#### Link to tracking issue

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50394 and http://github.com/open-telemetry/opentelemetry-collector/pull/15799

#### Authorship

- [x] I, a human, wrote this pull request description myself.
