### PR TITLE
add SHA to versioning in windows builds

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -282,6 +282,7 @@ jobs:
           docker build -f ./distributions/${{ inputs.distribution }}/Windows.dockerfile `
             -t ${{ env.TAG }} `
             --build-arg WIN_VERSION=2022 `
+            --build-arg WIN_VERSION_SHA=sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff `
             ./distributions/${{ inputs.distribution }}/
 
       - name: Export container image to tarball

--- a/cmd/goreleaser/internal/container.go
+++ b/cmd/goreleaser/internal/container.go
@@ -24,6 +24,7 @@ var (
 type containerImageOptions struct {
 	armVersion    string
 	winVersion    string
+	winVersionSHA string
 	binaryRelease bool
 }
 
@@ -129,6 +130,7 @@ func buildDockerImageWithOS(dist, os, arch string, opts containerImageOptions) c
 		imageConfig.BuildFlagTemplates = slices.Insert(
 			imageConfig.BuildFlagTemplates, 1,
 			fmt.Sprintf("--build-arg=WIN_VERSION=%s", opts.winVersion),
+			fmt.Sprintf("--build-arg=WIN_VERSION_SHA=%s", opts.winVersionSHA),
 		)
 		imageConfig.Dockerfile = "Windows.dockerfile"
 		imageConfig.Use = "docker"

--- a/cmd/goreleaser/internal/distro_contrib.go
+++ b/cmd/goreleaser/internal/distro_contrib.go
@@ -44,8 +44,8 @@ var (
 		}
 		d.ContainerImages = slices.Concat(
 			newContainerImages(d.Name, "linux", baseArchs, containerImageOptions{armVersion: "7"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019", winVersionSHA: "sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022", winVersionSHA: "sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff"}),
 		)
 		d.ContainerImageManifests = slices.Concat(
 			newContainerImageManifests(d.Name, "linux", baseArchs, containerImageOptions{}),

--- a/cmd/goreleaser/internal/distro_k8s.go
+++ b/cmd/goreleaser/internal/distro_k8s.go
@@ -14,8 +14,8 @@ var (
 		}
 		d.ContainerImages = slices.Concat(
 			newContainerImages(d.Name, "linux", k8sArchs, containerImageOptions{armVersion: "7"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019", winVersionSHA: "sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022", winVersionSHA: "sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff"}),
 		)
 		d.ContainerImageManifests = slices.Concat(
 			newContainerImageManifests(d.Name, "linux", k8sArchs, containerImageOptions{}),

--- a/cmd/goreleaser/internal/distro_otelcol.go
+++ b/cmd/goreleaser/internal/distro_otelcol.go
@@ -16,8 +16,8 @@ var (
 		}
 		d.ContainerImages = slices.Concat(
 			newContainerImages(d.Name, "linux", baseArchs, containerImageOptions{armVersion: "7"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019", winVersionSHA: "sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022", winVersionSHA: "sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff"}),
 		)
 		d.ContainerImageManifests = slices.Concat(
 			newContainerImageManifests(d.Name, "linux", baseArchs, containerImageOptions{}),

--- a/cmd/goreleaser/internal/distro_otlp.go
+++ b/cmd/goreleaser/internal/distro_otlp.go
@@ -16,8 +16,8 @@ var (
 		}
 		d.ContainerImages = slices.Concat(
 			newContainerImages(d.Name, "linux", baseArchs, containerImageOptions{armVersion: "7"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019"}),
-			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2019", winVersionSHA: "sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305"}),
+			newContainerImages(d.Name, "windows", winContainerArchs, containerImageOptions{winVersion: "2022", winVersionSHA: "sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff"}),
 		)
 		d.ContainerImageManifests = slices.Concat(
 			newContainerImageManifests(d.Name, "linux", baseArchs, containerImageOptions{}),

--- a/distributions/otelcol-contrib/.goreleaser.yaml
+++ b/distributions/otelcol-contrib/.goreleaser.yaml
@@ -314,6 +314,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2019
+      - --build-arg=WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}
@@ -337,6 +338,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2022
+      - --build-arg=WIN_VERSION_SHA=sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}

--- a/distributions/otelcol-contrib/Windows.dockerfile
+++ b/distributions/otelcol-contrib/Windows.dockerfile
@@ -1,6 +1,7 @@
 # escape=`
 ARG WIN_VERSION=2019
-FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+ARG WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}@${WIN_VERSION_SHA}
 
 COPY otelcol-contrib.exe ./otelcol-contrib.exe
 COPY config.yaml ./config.yaml

--- a/distributions/otelcol-k8s/.goreleaser.yaml
+++ b/distributions/otelcol-k8s/.goreleaser.yaml
@@ -179,6 +179,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2019
+      - --build-arg=WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}
@@ -200,6 +201,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2022
+      - --build-arg=WIN_VERSION_SHA=sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}

--- a/distributions/otelcol-k8s/Windows.dockerfile
+++ b/distributions/otelcol-k8s/Windows.dockerfile
@@ -1,6 +1,7 @@
 # escape=`
 ARG WIN_VERSION=2019
-FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+ARG WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}@${WIN_VERSION_SHA}
 
 COPY otelcol-k8s.exe ./otelcol-k8s.exe
 

--- a/distributions/otelcol-otlp/.goreleaser.yaml
+++ b/distributions/otelcol-otlp/.goreleaser.yaml
@@ -286,6 +286,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2019
+      - --build-arg=WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}
@@ -307,6 +308,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2022
+      - --build-arg=WIN_VERSION_SHA=sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}

--- a/distributions/otelcol-otlp/Windows.dockerfile
+++ b/distributions/otelcol-otlp/Windows.dockerfile
@@ -1,6 +1,7 @@
 # escape=`
 ARG WIN_VERSION=2019
-FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+ARG WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}@${WIN_VERSION_SHA}
 
 COPY otelcol-otlp.exe ./otelcol-otlp.exe
 

--- a/distributions/otelcol/.goreleaser.yaml
+++ b/distributions/otelcol/.goreleaser.yaml
@@ -306,6 +306,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2019
+      - --build-arg=WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}
@@ -329,6 +330,7 @@ dockers:
     build_flag_templates:
       - --pull
       - --build-arg=WIN_VERSION=2022
+      - --build-arg=WIN_VERSION_SHA=sha256:e4ce8c20390c3785c3cbeef15c579d186b3599d37525c596590cf4508e38d3ff
       - --platform=windows/amd64
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}

--- a/distributions/otelcol/Windows.dockerfile
+++ b/distributions/otelcol/Windows.dockerfile
@@ -1,6 +1,7 @@
 # escape=`
 ARG WIN_VERSION=2019
-FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}
+ARG WIN_VERSION_SHA=sha256:217694d5470363a77b86c42d439090b7466cd959ad5a15221c556a4707481305
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${WIN_VERSION}@${WIN_VERSION_SHA}
 
 COPY otelcol.exe ./otelcol.exe
 COPY config.yaml ./config.yaml


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This addresses warnings about pinned dependencies on tags for Windows builds from OSSF score card.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
