### PR TITLE
Relax requirements to allow components from CNCF Graduated/Incubating projects

### DIFF
--- a/distributions/README.md
+++ b/distributions/README.md
@@ -10,7 +10,10 @@ Distributions supported by the Collector SIG should fulfill the following criter
 2. Should meet general needs and be desired by many users.
 3. Should not be specific to any vendor.
 4. May be focused on development or proof of concept use cases.  The distribution should clearly indicate whether the Collector SIG recommends the distribution be used in production environments.
-5. Must only include components from the `open-telemetry` org.
+5. Must only include components whose source repositories are hosted in the `open-telemetry`
+   GitHub organization or in the GitHub organization of a CNCF
+   [graduated](https://www.cncf.io/projects/) or
+   [incubating](https://www.cncf.io/projects/#incubating) project.
     - Components that are marked [Unmaintained](https://github.com/open-telemetry/opentelemetry-collector#unmaintained) will be kept in any distributions for six months. After six months of being unmaintained the component will be removed from the distributions.
 6. Must only include components that are properly tagged as Go modules. Updates to components will only be considered if they correspond to a tag.
 7. Have a clearly defined list of criteria for which components are included.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Relax requirements so Collector components can live outside the OTel GitHub org. Goal here is to foster collaboration with the broader CNCF community.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-releases/issues/1618

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
