### PR TITLE
[chore] [ci] don't fail Windows docker-tests on collector stderr output

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -428,7 +428,13 @@ jobs:
           echo "Sleeping for a bit..."
           sleep 10
           echo "Checking logs for correct startup..."
-          docker logs $env:INPUTS_DISTRIBUTION *> "docker-logs-${env:INPUTS_DISTRIBUTION}.log"
+          # The collector writes its logs to stderr. Under GitHub Actions the
+          # powershell shell runs with $ErrorActionPreference = 'Stop', so any
+          # native-command stderr output is promoted to a terminating
+          # NativeCommandError. Merge stderr into stdout and don't treat it as
+          # fatal so we can inspect the logs.
+          $ErrorActionPreference = 'Continue'
+          docker logs $env:INPUTS_DISTRIBUTION 2>&1 | Out-File -FilePath "docker-logs-${env:INPUTS_DISTRIBUTION}.log"
           if (Get-Content "docker-logs-${env:INPUTS_DISTRIBUTION}.log" | Select-String -Pattern "Everything is ready.") {
             echo "$env:INPUTS_DISTRIBUTION started up correctly"
           } else {


### PR DESCRIPTION
The Windows `docker-tests` step runs under `shell: powershell` (Windows PowerShell 5.1) with `$ErrorActionPreference = 'Stop'`. The collector writes its startup logs to stderr, and capturing them with `*>` promotes that native-command output to a terminating `NativeCommandError`, so the step exits 1 even though the container starts fine and the `"Everything is ready."` check is never reached.

This broke at #1627, which added `shell: powershell` to the step. Before that it ran under `pwsh` (PowerShell 7), which doesn't promote native stderr to a terminating error. It has failed on `main` for Core, OTLP, and k8s Windows docker-tests since; every PR inherits the red checks.

## Fix
Set `$ErrorActionPreference = 'Continue'` for the log capture and use `2>&1 | Out-File`, so stderr is captured without being treated as fatal. The readiness check is unchanged.

- [ ] I, a human, wrote this pull request description myself.