### PR TITLE
[chore] Fix v0.160.0 CHANGELOG: OBI shipped as v0.12.2, not v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Enhancements 💡
 
-- `otelcol-contrib`: Upgrade go.opentelemetry.io/obi to v0.11.0. (#1604)
+- `otelcol-contrib`: Upgrade go.opentelemetry.io/obi to v0.12.2. (#1615, #1622)
 
 ## v0.159.0
 


### PR DESCRIPTION
### Description

The `v0.160.0` CHANGELOG says OBI was upgraded to v0.11.0, but the release actually shipped **v0.12.2**.

`distributions/otelcol-contrib/manifest.yaml` at `v0.160.0` pins `go.opentelemetry.io/obi v0.12.2`, and `scripts/prepare-obi.sh` resolves the OBI source tarball from that manifest value, so v0.12.2 is what got compiled into `otelcol-contrib:0.160.0`.

The 0.11.0 entry came from #1604 (closed unmerged; the bump landed via #1615). Renovate then bumped 0.11.0 → 0.12.2 in #1622, which touched only the manifest and added no `.chloggen/` entry — Renovate PRs are labeled `dependencies`, which `.github/workflows/changelog.yml` exempts from the chloggen requirement.

This edits the already-released `v0.160.0` section in place because chloggen entries can only land in the *next* release, and leaving the shipped version misreported would mislead anyone assessing upgrade impact (v0.159.0 shipped OBI v0.10.0, so this release is really a v0.10.0 → v0.12.2 jump).

`[chore]` in the title so the Changelog action permits the direct `CHANGELOG.md` edit.

Refs #1622. See https://github.com/open-telemetry/opentelemetry-collector-releases/issues/1636 for the recurrence-prevention discussion.

### Testing

n/a — documentation only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
