### PR TITLE
[chore] Require a changelog entry for OBI update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -124,6 +124,14 @@
       ]
     },
     {
+      "matchPackageNames": [
+        "go.opentelemetry.io/obi{/,}**"
+      ],
+      "labels": [
+        "renovatebot"
+      ]
+    },
+    {
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
#### Description

`renovate.json` labels every Renovate PR with `renovatebot` + `dependencies`, and `.github/workflows/changelog.yml` skips the chloggen requirement for anything labeled `dependencies`. That exemption makes sense for ordinary Go dependencies, but OBI is a user-visible bundled component — the version in `distributions/otelcol-contrib/manifest.yaml` is what `scripts/prepare-obi.sh` downloads and compiles into the distribution. As a result #1622 raised `go.opentelemetry.io/obi` from v0.11.0 to v0.12.2 with no changelog entry, and v0.160.0 shipped OBI v0.12.2 while the CHANGELOG reported v0.11.0 (fixed in #1637).

This adds a `packageRules` entry that overrides the label list for `go.opentelemetry.io/obi`, keeping `renovatebot` and dropping `dependencies`. The rule does not restrict `matchManagers`: OBI is declared only in `distributions/otelcol-contrib/manifest.yaml`, which the `ocb` manager handles, not `gomod`.

Note that Renovate cannot add a `.chloggen/` entry itself, so an OBI bump PR will open with the Changelog check failing until a maintainer adds the entry (or applies `Skip Changelog`). That is what makes the bump impossible to merge unnoticed, but it does mean a red check on every OBI PR by design.

#### Link to tracking issue

Fixes #1636

#### Authorship

- [x] I, a human, wrote this pull request description myself.
