### PR TITLE
chore: move go renovate updates to separate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -141,6 +141,15 @@
       "enabled": false
     },
     {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
+      "groupName": "Go version"
+    },
+    {
       "matchPackageNames": [
         "goreleaser/goreleaser-pro",
         "github.com/goreleaser/goreleaser-pro/v2",

--- a/renovate.json
+++ b/renovate.json
@@ -150,6 +150,15 @@
       "groupName": "Go version"
     },
     {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "go"
+      ],
+      "groupName": "Go version"
+    },
+    {
       "matchPackageNames": [
         "goreleaser/goreleaser-pro",
         "github.com/goreleaser/goreleaser-pro/v2",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR separates go version bumps from other github actions renovate updates. We usually want to bump the go version at a later stage and not right away when it comes out (and renovate opens the PR for it), but we do want to merge other github actions deps bumps that are put into the same PR. This PR separates the dependencies out.

Examples for a case where go had to be reverted and the rest of the bumps were merged:
- https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1642
- https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1620

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

No issue

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
